### PR TITLE
fix(action): bump setup-node to v6 (#82)

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,7 +17,7 @@ runs:
     using: composite
     steps:
         - name: Setup Node.js
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v6
           with:
               node-version: ${{ inputs.node-version }}
               cache: npm

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ jobs:
         name: WP latest
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -46,7 +46,7 @@ jobs:
                   WP_ADMIN_USER: admin
                   WP_ADMIN_PASSWORD: password
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v7
               if: always()
               with:
                   name: playwright-report-wp-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.2] - 2026-05-25
+
+### Changed
+
+- Bumped `actions/setup-node` in the composite build action from v4 to
+  v6 ahead of the GitHub Actions Node 20 runtime removal (forced
+  June 2nd, 2026; removed September 16th, 2026) (#82)
+- Bumped `actions/checkout` (v4 → v6) and `actions/upload-artifact`
+  (v4 → v7) in the e2e workflow for the same Node 20 deprecation
+
 ## [1.4.1] - 2026-05-25
 
 ### Added
@@ -207,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Renamed theme to Sovereignty
 - Updated Composer package name to `apermo/sovereignty`
 
+[1.4.2]: https://github.com/apermo/sovereignty/compare/1.4.1...1.4.2
 [1.4.1]: https://github.com/apermo/sovereignty/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/apermo/sovereignty/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/apermo/sovereignty/compare/1.2.0...1.3.0

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In a GitHub Actions deploy workflow, the same step is available as a
 reusable composite action:
 
 ```yaml
-- uses: apermo/sovereignty/.github/actions/build@v1.4.1
+- uses: apermo/sovereignty/.github/actions/build@v1.4.2
   with:
       working-directory: web/app/themes/sovereignty
 ```

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "apermo/sovereignty",
 	"description": "Pure Zen - Fork of Pfefferle's Autonomie Theme",
 	"type": "wordpress-theme",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"license": "MIT",
 	"homepage": "https://github.com/apermo/sovereignty",
 	"support": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereignty",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "testedUpTo": "6.9",
   "description": "Semantic, responsive WordPress theme with deep IndieWeb support. Fork of Autonomie by Matthias Pfefferle.",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump `actions/setup-node` in the composite build action from v4 to v6
  ahead of the GitHub Actions Node 20 runtime removal
- While in the area, bump `actions/checkout` (v4 → v6) and
  `actions/upload-artifact` (v4 → v7) in the inlined e2e workflow
- Release 1.4.2

## Background

GitHub will force Node 24 on June 2nd, 2026 and remove Node 20 entirely
on September 16th, 2026. The composite action at
`.github/actions/build/action.yml` (used by chrdm.de's deploy and any
other consumer) currently pins `actions/setup-node@v4`, which runs on
Node 20 and emits a deprecation warning today.

`actions/setup-node@v6` runs on Node 24 and is backward-compatible for
the inputs this action uses (`node-version`, `cache`,
`cache-dependency-path`).

## Test plan

- [x] `actionlint .github/workflows/e2e.yml` — clean
- [ ] e2e workflow run on this PR shows no Node 20 deprecation warnings
- [ ] After merge + tag v1.4.2, chrdm.de bumps its deploy reference

Fixes #82