### PR TITLE
fix(msls): pass required arg to msls_get_switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.1] - 2026-06-03
+
+### Fixed
+
+- Fatal `ArgumentCountError` in the MSLS integration: `msls_get_switcher()`
+  takes a required `$attr` argument, so calling it with none crashed every
+  front-end page when the Multisite Language Switcher plugin was active.
+  Now called with an empty array
+
 ## [1.5.0] - 2026-06-03
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "apermo/sovereignty",
 	"description": "Pure Zen - Fork of Pfefferle's Autonomie Theme",
 	"type": "wordpress-theme",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"license": "MIT",
 	"homepage": "https://github.com/apermo/sovereignty",
 	"support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereignty",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereignty",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereignty",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "testedUpTo": "6.9",
   "description": "Semantic, responsive WordPress theme with deep IndieWeb support. Fork of Autonomie by Matthias Pfefferle.",
   "repository": {

--- a/src/Integration/Msls.php
+++ b/src/Integration/Msls.php
@@ -32,7 +32,7 @@ class Msls {
 			return;
 		}
 
-		$switcher = msls_get_switcher();
+		$switcher = msls_get_switcher( [] );
 
 		if ( ! \is_string( $switcher ) || \trim( $switcher ) === '' ) {
 			return; // No translation, or empty/whitespace markup — render nothing.

--- a/tests/Unit/Integration/MslsTest.php
+++ b/tests/Unit/Integration/MslsTest.php
@@ -54,7 +54,7 @@ class MslsTest extends TestCase {
 	 * @return void
 	 */
 	public function test_display_wraps_switcher_when_present(): void {
-		Functions\when( 'msls_get_switcher' )->justReturn( '<a href="https://example.tld/de/">DE</a>' );
+		Functions\expect( 'msls_get_switcher' )->once()->with( [] )->andReturn( '<a href="https://example.tld/de/">DE</a>' );
 
 		$this->expectOutputString(
 			'<nav class="language-switcher" aria-label="Languages"><a href="https://example.tld/de/">DE</a></nav>',
@@ -69,7 +69,7 @@ class MslsTest extends TestCase {
 	 * @return void
 	 */
 	public function test_display_renders_nothing_without_translation(): void {
-		Functions\when( 'msls_get_switcher' )->justReturn( '' );
+		Functions\expect( 'msls_get_switcher' )->once()->with( [] )->andReturn( '' );
 
 		$this->expectOutputString( '' );
 
@@ -82,7 +82,7 @@ class MslsTest extends TestCase {
 	 * @return void
 	 */
 	public function test_display_renders_nothing_when_not_a_string(): void {
-		Functions\when( 'msls_get_switcher' )->justReturn( false );
+		Functions\expect( 'msls_get_switcher' )->once()->with( [] )->andReturn( false );
 
 		$this->expectOutputString( '' );
 


### PR DESCRIPTION
## Summary

Fixes a fatal `ArgumentCountError` introduced with the MSLS integration in 1.5.0. Every front-end page 500s when
the Multisite Language Switcher plugin is active.

## Bug

`Integration\Msls::display()` called `msls_get_switcher()` with no arguments, but the plugin's signature is
`function msls_get_switcher( $attr ): string` — `$attr` is a **required** positional parameter with no default:

```
ArgumentCountError: Too few arguments to function msls_get_switcher(),
0 passed in src/Integration/Msls.php on line 35 and exactly 1 expected
```

The `function_exists( 'msls_get_switcher' )` guard passes (the plugin is loaded), so the integration runs and then
fatals on the call. Confirmed reproduced on a clean DDEV multisite install with MSLS active.

## Fix

```php
$switcher = msls_get_switcher( [] );   // $attr is a required positional param
```

The plugin coerces non-arrays internally (`is_array( $attr ) ? $attr : array()`), so `[]` is the natural value.
The existing empty-string/whitespace guard after the call is unchanged.

## Tests

The original unit tests stubbed `msls_get_switcher` arg-agnostically, which is why they didn't catch this. They now
use `expect( 'msls_get_switcher' )->once()->with( [] )`, asserting the required argument is passed so the signature
can't regress unnoticed.

- PHPCS (Apermo ruleset) + PHPStan level 5 pass
- 83 unit tests pass

Bumps version to 1.5.1.