### PR TITLE
fix(msls): show current language with friendly labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.2] - 2026-06-04
+
+### Changed
+
+- The MSLS language switcher now builds the theme's own markup from the
+  plugin's blog collection instead of echoing `msls_get_switcher()`. It
+  shows the current language (marked `aria-current="page"`) alongside the
+  translated ones, and renders friendly two-letter labels (`EN`/`DE`)
+  derived from the locale — independent of the MSLS *Display* setting.
+  Untranslated languages are skipped, and `hreflang` is added to each
+  alternate link (#89)
+
 ## [1.5.1] - 2026-06-03
 
 ### Fixed

--- a/assets/sass/_page.scss
+++ b/assets/sass/_page.scss
@@ -127,8 +127,11 @@
 			}
 		}
 
-		[aria-current="page"] {
+		.current {
+			color: $dark-gray;
+			color: var(--color-dark-gray);
 			font-weight: 700;
+			cursor: default;
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "apermo/sovereignty",
 	"description": "Pure Zen - Fork of Pfefferle's Autonomie Theme",
 	"type": "wordpress-theme",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"license": "MIT",
 	"homepage": "https://github.com/apermo/sovereignty",
 	"support": {
@@ -46,7 +46,8 @@
 		"yoast/phpunit-polyfills": "^3.0",
 		"wpackagist-plugin/pwa": "*",
 		"wpackagist-plugin/indieweb-post-kinds": "*",
-		"yoast/wordpress-seo": "^27.2"
+		"yoast/wordpress-seo": "^27.2",
+		"wpackagist-plugin/multisite-language-switcher": "*"
 	},
 	"scripts": {
 		"cs": "phpcs --warning-severity=0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18c385663c0bd42a4a5f44212174874e",
+    "content-hash": "00e6626213b38999559e4c41e378bf23",
     "packages": [
         {
             "name": "composer/installers",
@@ -4787,6 +4787,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/indieweb-post-kinds/"
+        },
+        {
+            "name": "wpackagist-plugin/multisite-language-switcher",
+            "version": "2.10.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/multisite-language-switcher/",
+                "reference": "tags/2.10.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/multisite-language-switcher.2.10.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/multisite-language-switcher/"
         },
         {
             "name": "wpackagist-plugin/pwa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereignty",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereignty",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereignty",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "testedUpTo": "6.9",
   "description": "Semantic, responsive WordPress theme with deep IndieWeb support. Fork of Autonomie by Matthias Pfefferle.",
   "repository": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,7 @@ parameters:
         - vendor/pfefferle/activitypub/includes
         - vendor/wpackagist-plugin/pwa
         - vendor/wpackagist-plugin/indieweb-post-kinds
+        - vendor/wpackagist-plugin/multisite-language-switcher
     strictRules:
         allRules: false
         booleansInConditions: true

--- a/src/Integration/Msls.php
+++ b/src/Integration/Msls.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Apermo\Sovereignty\Integration;
 
+use lloc\Msls\MslsBlog;
+
 /**
  * Multisite Language Switcher integration: renders the switcher next to the search form.
+ *
+ * Builds the theme's own markup from the plugin's structured blog collection so the
+ * current language is shown and labels are friendly two-letter codes, independent of
+ * the MSLS Display admin setting.
  *
  * @link https://github.com/lloc/Multisite-Language-Switcher
  *
@@ -28,19 +34,102 @@ class Msls {
 	 * @return void
 	 */
 	public static function display(): void {
-		if ( ! \function_exists( 'msls_get_switcher' ) ) {
+		if ( ! \function_exists( 'msls_blog_collection' ) || ! \function_exists( 'msls_options' ) ) {
 			return;
 		}
 
-		$switcher = msls_get_switcher( [] );
+		$languages = self::get_languages();
 
-		if ( ! \is_string( $switcher ) || \trim( $switcher ) === '' ) {
-			return; // No translation, or empty/whitespace markup — render nothing.
+		if ( empty( $languages ) ) {
+			return;
 		}
 
-		echo '<nav class="language-switcher" aria-label="' . esc_attr__( 'Languages', 'sovereignty' ) . '">';
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- msls_get_switcher() returns safe link markup.
-		echo $switcher;
-		echo '</nav>';
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render() escapes every dynamic value.
+		echo self::render( $languages );
+	}
+
+	/**
+	 * Collects the current and translated languages from the MSLS blog collection.
+	 *
+	 * Returns an empty array when no other language has a translation for the current
+	 * content, so single-language pages render nothing.
+	 *
+	 * @return array<int, array{label: string, locale: string, url: string, current: bool}>
+	 */
+	private static function get_languages(): array {
+		$collection = msls_blog_collection();
+		$options    = msls_options();
+
+		$languages = [];
+		$has_other = false;
+
+		foreach ( $collection->get_objects() as $blog ) {
+			if ( $collection->is_current_blog( $blog ) ) {
+				$languages[] = self::language( $blog, '', true );
+				continue;
+			}
+
+			$url = $blog->get_url( $options );
+
+			if ( empty( $url ) ) {
+				continue;
+			}
+
+			$has_other   = true;
+			$languages[] = self::language( $blog, (string) $url, false );
+		}
+
+		return $has_other ? $languages : [];
+	}
+
+	/**
+	 * Builds a single language entry from an MSLS blog.
+	 *
+	 * @param MslsBlog $blog    The blog representing a language.
+	 * @param string   $url     Translation URL, empty for the current language.
+	 * @param bool     $current Whether this is the current language.
+	 *
+	 * @return array{label: string, locale: string, url: string, current: bool}
+	 */
+	private static function language( MslsBlog $blog, string $url, bool $current ): array {
+		return [
+			'label'   => \strtoupper( $blog->get_alpha2() ),
+			'locale'  => $blog->get_language(),
+			'url'     => $url,
+			'current' => $current,
+		];
+	}
+
+	/**
+	 * Renders the switcher markup.
+	 *
+	 * @param array<int, array{label: string, locale: string, url: string, current: bool}> $languages Language entries.
+	 *
+	 * @return string
+	 */
+	private static function render( array $languages ): string {
+		$html = '<nav class="language-switcher" aria-label="' . esc_attr__( 'Languages', 'sovereignty' ) . '">';
+
+		foreach ( $languages as $language ) {
+			$alpha2 = \strtolower( \substr( $language['locale'], 0, 2 ) );
+
+			if ( $language['current'] ) {
+				$html .= \sprintf(
+					'<span class="current" aria-current="page" lang="%s">%s</span>',
+					esc_attr( $alpha2 ),
+					esc_html( $language['label'] ),
+				);
+				continue;
+			}
+
+			$html .= \sprintf(
+				'<a href="%s" hreflang="%s">%s</a>',
+				esc_url( $language['url'] ),
+				esc_attr( $alpha2 ),
+				esc_html( $language['label'] ),
+			);
+		}
+
+		return $html . '</nav>';
 	}
 }

--- a/src/Integration/Msls.php
+++ b/src/Integration/Msls.php
@@ -54,7 +54,7 @@ class Msls {
 	 * Returns an empty array when no other language has a translation for the current
 	 * content, so single-language pages render nothing.
 	 *
-	 * @return array<int, array{label: string, locale: string, url: string, current: bool}>
+	 * @return array<int, array{label: string, lang: string, url: string, current: bool}>
 	 */
 	private static function get_languages(): array {
 		$collection = msls_blog_collection();
@@ -89,12 +89,12 @@ class Msls {
 	 * @param string   $url     Translation URL, empty for the current language.
 	 * @param bool     $current Whether this is the current language.
 	 *
-	 * @return array{label: string, locale: string, url: string, current: bool}
+	 * @return array{label: string, lang: string, url: string, current: bool}
 	 */
 	private static function language( MslsBlog $blog, string $url, bool $current ): array {
 		return [
 			'label'   => \strtoupper( $blog->get_alpha2() ),
-			'locale'  => $blog->get_language(),
+			'lang'    => \strtolower( $blog->get_alpha2() ),
 			'url'     => $url,
 			'current' => $current,
 		];
@@ -103,7 +103,7 @@ class Msls {
 	/**
 	 * Renders the switcher markup.
 	 *
-	 * @param array<int, array{label: string, locale: string, url: string, current: bool}> $languages Language entries.
+	 * @param array<int, array{label: string, lang: string, url: string, current: bool}> $languages Language entries.
 	 *
 	 * @return string
 	 */
@@ -111,12 +111,10 @@ class Msls {
 		$html = '<nav class="language-switcher" aria-label="' . esc_attr__( 'Languages', 'sovereignty' ) . '">';
 
 		foreach ( $languages as $language ) {
-			$alpha2 = \strtolower( \substr( $language['locale'], 0, 2 ) );
-
 			if ( $language['current'] ) {
 				$html .= \sprintf(
 					'<span class="current" aria-current="page" lang="%s">%s</span>',
-					esc_attr( $alpha2 ),
+					esc_attr( $language['lang'] ),
 					esc_html( $language['label'] ),
 				);
 				continue;
@@ -125,7 +123,7 @@ class Msls {
 			$html .= \sprintf(
 				'<a href="%s" hreflang="%s">%s</a>',
 				esc_url( $language['url'] ),
-				esc_attr( $alpha2 ),
+				esc_attr( $language['lang'] ),
 				esc_html( $language['label'] ),
 			);
 		}

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -177,7 +177,7 @@ class Theme {
 			Integration\Yoast::register();
 		}
 
-		if ( \function_exists( 'msls_get_switcher' ) ) {
+		if ( \function_exists( 'msls_blog_collection' ) ) {
 			Integration\Msls::register();
 		}
 	}

--- a/tests/Unit/Integration/MslsTest.php
+++ b/tests/Unit/Integration/MslsTest.php
@@ -7,6 +7,9 @@ namespace Apermo\Sovereignty\Tests\Unit\Integration;
 use Apermo\Sovereignty\Integration\Msls;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use lloc\Msls\MslsBlog;
+use Mockery;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -25,6 +28,9 @@ class MslsTest extends TestCase {
 		parent::setUp();
 		Monkey\setUp();
 		Functions\when( 'esc_attr__' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_url' )->returnArg();
 	}
 
 	/**
@@ -35,6 +41,42 @@ class MslsTest extends TestCase {
 	protected function tearDown(): void {
 		Monkey\tearDown();
 		parent::tearDown();
+	}
+
+	/**
+	 * Builds a mock MslsBlog for the given locale and translation URL.
+	 *
+	 * @param string $locale The blog locale, e.g. de_DE.
+	 * @param string $url    The translation URL, or empty when none exists.
+	 *
+	 * @return MockInterface
+	 */
+	private function blog( string $locale, string $url ): MockInterface {
+		$blog = Mockery::mock( MslsBlog::class );
+		$blog->shouldReceive( 'get_language' )->andReturn( $locale );
+		$blog->shouldReceive( 'get_alpha2' )->andReturn( \substr( $locale, 0, 2 ) );
+		$blog->shouldReceive( 'get_url' )->andReturn( $url );
+
+		return $blog;
+	}
+
+	/**
+	 * Stubs the MSLS collection and options around the given blogs.
+	 *
+	 * @param array<int, MockInterface> $blogs   Blog mocks in display order.
+	 * @param MockInterface             $current The blog treated as current.
+	 *
+	 * @return void
+	 */
+	private function stub_collection( array $blogs, MockInterface $current ): void {
+		$collection = Mockery::mock();
+		$collection->shouldReceive( 'get_objects' )->andReturn( $blogs );
+		$collection->shouldReceive( 'is_current_blog' )->andReturnUsing(
+			static fn ( $blog ) => $blog === $current,
+		);
+
+		Functions\when( 'msls_blog_collection' )->justReturn( $collection );
+		Functions\when( 'msls_options' )->justReturn( Mockery::mock() );
 	}
 
 	/**
@@ -49,40 +91,57 @@ class MslsTest extends TestCase {
 	}
 
 	/**
-	 * Verify display() wraps the switcher markup in a labelled nav.
+	 * Verify display() marks the current language and links the translated ones.
 	 *
 	 * @return void
 	 */
-	public function test_display_wraps_switcher_when_present(): void {
-		Functions\expect( 'msls_get_switcher' )->once()->with( [] )->andReturn( '<a href="https://example.tld/de/">DE</a>' );
+	public function test_display_marks_current_and_links_others(): void {
+		$en = $this->blog( 'en_US', '' );
+		$de = $this->blog( 'de_DE', 'https://example.tld/de/' );
+
+		$this->stub_collection( [ $en, $de ], $en );
 
 		$this->expectOutputString(
-			'<nav class="language-switcher" aria-label="Languages"><a href="https://example.tld/de/">DE</a></nav>',
+			'<nav class="language-switcher" aria-label="Languages">'
+			. '<span class="current" aria-current="page" lang="en">EN</span>'
+			. '<a href="https://example.tld/de/" hreflang="de">DE</a>'
+			. '</nav>',
 		);
 
 		Msls::display();
 	}
 
 	/**
-	 * Verify display() renders nothing when no translation exists.
+	 * Verify display() skips languages that have no translation for the content.
 	 *
 	 * @return void
 	 */
-	public function test_display_renders_nothing_without_translation(): void {
-		Functions\expect( 'msls_get_switcher' )->once()->with( [] )->andReturn( '' );
+	public function test_display_skips_untranslated_languages(): void {
+		$en = $this->blog( 'en_US', '' );
+		$de = $this->blog( 'de_DE', 'https://example.tld/de/' );
+		$fr = $this->blog( 'fr_FR', '' );
 
-		$this->expectOutputString( '' );
+		$this->stub_collection( [ $en, $de, $fr ], $en );
+
+		$this->expectOutputString(
+			'<nav class="language-switcher" aria-label="Languages">'
+			. '<span class="current" aria-current="page" lang="en">EN</span>'
+			. '<a href="https://example.tld/de/" hreflang="de">DE</a>'
+			. '</nav>',
+		);
 
 		Msls::display();
 	}
 
 	/**
-	 * Verify display() renders nothing when the switcher is not a string.
+	 * Verify display() renders nothing when no other language has a translation.
 	 *
 	 * @return void
 	 */
-	public function test_display_renders_nothing_when_not_a_string(): void {
-		Functions\expect( 'msls_get_switcher' )->once()->with( [] )->andReturn( false );
+	public function test_display_renders_nothing_without_other_languages(): void {
+		$en = $this->blog( 'en_US', '' );
+
+		$this->stub_collection( [ $en ], $en );
 
 		$this->expectOutputString( '' );
 


### PR DESCRIPTION
## Summary

Enhances the MSLS language switcher (issue #89, `a11y`): it now shows the **current** language and renders
**friendly labels** instead of raw locale codes. Builds the theme's own markup from the plugin's structured blog
collection rather than echoing `msls_get_switcher()`.

Closes #89

## Behaviour

- **Current language included**, rendered as `<span class="current" aria-current="page" lang="…">` so users see
  where they are. Alternate languages remain `<a>` links.
- **Friendly two-letter labels** (`EN`/`DE`) derived from the locale, independent of the MSLS *Display* admin
  setting (which otherwise renders raw `en_US`).
- **Switches to the translated content**: alternate links use `MslsBlog::get_url()`, i.e. the translated permalink
  of the current post/page. Languages with no translation return no URL and are **skipped** — no dead links, and
  nothing renders when there's no other language to switch to (no empty `<nav>`).
- `hreflang` added to each alternate link.

## Implementation

- `src/Integration/Msls.php` — rewritten to iterate `msls_blog_collection()->get_objects()`, mark the current
  blog, resolve translation URLs via `get_url( msls_options() )`, and build escaped markup.
- `src/Theme.php` — registration guard switched to `function_exists( 'msls_blog_collection' )` (the API now used).
- `assets/sass/_page.scss` — styles the non-link `.current` item to match the link colour.
- `phpstan.neon.dist` + `composer.json`/`composer.lock` — MSLS added as a dev dependency and to the PHPStan scan
  paths so its functions and the `MslsBlog` type resolve during static analysis.

## Verification

- `composer cs` (PHPCS Apermo), `composer analyse` (PHPStan level 5), 83 unit tests — all pass.
- Live on a DDEV multisite with MSLS active: the German homepage renders
  `<span class="current" aria-current="page" lang="de">DE</span>` + `<a href="…" hreflang="en">EN</a>` (HTTP 200);
  a post with no translation renders nothing.

Bumps version to 1.5.2.