### PR TITLE
fix(msls): resolve post translation links, always show languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.3] - 2026-06-04
+
+### Fixed
+
+- The MSLS language switcher resolved translation URLs with the generic
+  `msls_options()` singleton, which is not request-aware, so it never
+  found a post's translation and the switcher disappeared on single
+  posts. It now uses `MslsOptions::create()` (the request-aware factory
+  MSLS itself uses), so post translations resolve correctly.
+
+### Changed
+
+- Every language is now always shown in the switcher. When a language
+  has no translation for the current content, it links to that
+  language's home page instead of being hidden.
+
 ## [1.5.2] - 2026-06-04
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "apermo/sovereignty",
 	"description": "Pure Zen - Fork of Pfefferle's Autonomie Theme",
 	"type": "wordpress-theme",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"license": "MIT",
 	"homepage": "https://github.com/apermo/sovereignty",
 	"support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereignty",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereignty",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereignty",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "testedUpTo": "6.9",
   "description": "Semantic, responsive WordPress theme with deep IndieWeb support. Fork of Autonomie by Matthias Pfefferle.",
   "repository": {

--- a/src/Integration/Msls.php
+++ b/src/Integration/Msls.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Apermo\Sovereignty\Integration;
 
 use lloc\Msls\MslsBlog;
+use lloc\Msls\MslsBlogCollection;
+use lloc\Msls\MslsOptions;
+use lloc\Msls\OptionsInterface;
 
 /**
  * Multisite Language Switcher integration: renders the switcher next to the search form.
@@ -34,11 +37,11 @@ class Msls {
 	 * @return void
 	 */
 	public static function display(): void {
-		if ( ! \function_exists( 'msls_blog_collection' ) || ! \function_exists( 'msls_options' ) ) {
+		if ( ! \function_exists( 'msls_blog_collection' ) ) {
 			return;
 		}
 
-		$languages = self::get_languages();
+		$languages = self::get_languages( msls_blog_collection(), MslsOptions::create() );
 
 		if ( empty( $languages ) ) {
 			return;
@@ -49,17 +52,19 @@ class Msls {
 	}
 
 	/**
-	 * Collects the current and translated languages from the MSLS blog collection.
+	 * Collects every language from the MSLS blog collection.
 	 *
-	 * Returns an empty array when no other language has a translation for the current
-	 * content, so single-language pages render nothing.
+	 * Each alternate language links to the translated content when it exists, otherwise
+	 * to that language's home page, so the full set of languages is always offered.
+	 * Returns an empty array when no other language exists, so single-language sites
+	 * render nothing.
+	 *
+	 * @param MslsBlogCollection $collection The plugin's blog collection.
+	 * @param OptionsInterface   $options    Request-aware options used to resolve URLs.
 	 *
 	 * @return array<int, array{label: string, lang: string, url: string, current: bool}>
 	 */
-	private static function get_languages(): array {
-		$collection = msls_blog_collection();
-		$options    = msls_options();
-
+	private static function get_languages( MslsBlogCollection $collection, OptionsInterface $options ): array {
 		$languages = [];
 		$has_other = false;
 
@@ -72,7 +77,7 @@ class Msls {
 			$url = $blog->get_url( $options );
 
 			if ( empty( $url ) ) {
-				continue;
+				$url = get_home_url( (int) $blog->userblog_id );
 			}
 
 			$has_other   = true;

--- a/tests/Unit/Integration/MslsTest.php
+++ b/tests/Unit/Integration/MslsTest.php
@@ -8,10 +8,13 @@ use Apermo\Sovereignty\Integration\Msls;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use lloc\Msls\MslsBlog;
+use lloc\Msls\MslsBlogCollection;
+use lloc\Msls\OptionsInterface;
 use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 /**
  * Tests for the Msls integration class.
@@ -44,39 +47,53 @@ class MslsTest extends TestCase {
 	}
 
 	/**
-	 * Builds a mock MslsBlog for the given locale and translation URL.
+	 * Invokes a private static method on the Msls class.
+	 *
+	 * @param string $method The method name.
+	 * @param mixed  ...$args The arguments to pass.
+	 *
+	 * @return mixed
+	 */
+	private function invoke( string $method, mixed ...$args ): mixed {
+		$reflection = new ReflectionMethod( Msls::class, $method );
+
+		return $reflection->invoke( null, ...$args );
+	}
+
+	/**
+	 * Builds a mock MslsBlog for the given locale, URL and blog id.
 	 *
 	 * @param string $locale The blog locale, e.g. de_DE.
 	 * @param string $url    The translation URL, or empty when none exists.
+	 * @param int    $id     The blog id, used for the home-page fallback.
 	 *
 	 * @return MockInterface
 	 */
-	private function blog( string $locale, string $url ): MockInterface {
+	private function blog( string $locale, string $url, int $id = 0 ): MockInterface {
 		$blog = Mockery::mock( MslsBlog::class );
-		$blog->shouldReceive( 'get_language' )->andReturn( $locale );
 		$blog->shouldReceive( 'get_alpha2' )->andReturn( \substr( $locale, 0, 2 ) );
 		$blog->shouldReceive( 'get_url' )->andReturn( $url );
+		$blog->userblog_id = $id;
 
 		return $blog;
 	}
 
 	/**
-	 * Stubs the MSLS collection and options around the given blogs.
+	 * Builds a mock collection over the given blogs.
 	 *
 	 * @param array<int, MockInterface> $blogs   Blog mocks in display order.
 	 * @param MockInterface             $current The blog treated as current.
 	 *
-	 * @return void
+	 * @return MockInterface
 	 */
-	private function stub_collection( array $blogs, MockInterface $current ): void {
-		$collection = Mockery::mock();
+	private function collection( array $blogs, MockInterface $current ): MockInterface {
+		$collection = Mockery::mock( MslsBlogCollection::class );
 		$collection->shouldReceive( 'get_objects' )->andReturn( $blogs );
 		$collection->shouldReceive( 'is_current_blog' )->andReturnUsing(
 			static fn ( $blog ) => $blog === $current,
 		);
 
-		Functions\when( 'msls_blog_collection' )->justReturn( $collection );
-		Functions\when( 'msls_options' )->justReturn( Mockery::mock() );
+		return $collection;
 	}
 
 	/**
@@ -91,58 +108,116 @@ class MslsTest extends TestCase {
 	}
 
 	/**
-	 * Verify display() marks the current language and links the translated ones.
+	 * Verify the current language is marked and translated ones are linked.
 	 *
 	 * @return void
 	 */
-	public function test_display_marks_current_and_links_others(): void {
+	public function test_get_languages_marks_current_and_links_translations(): void {
 		$en = $this->blog( 'en_US', '' );
 		$de = $this->blog( 'de_DE', 'https://example.tld/de/' );
 
-		$this->stub_collection( [ $en, $de ], $en );
+		$result = $this->invoke( 'get_languages', $this->collection( [ $en, $de ], $en ), Mockery::mock( OptionsInterface::class ) );
 
-		$this->expectOutputString(
+		$this->assertSame(
+			[
+				[
+					'label' => 'EN',
+					'lang' => 'en',
+					'url' => '',
+					'current' => true,
+				],
+				[
+					'label' => 'DE',
+					'lang' => 'de',
+					'url' => 'https://example.tld/de/',
+					'current' => false,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 * Verify a language with no translation falls back to its home page.
+	 *
+	 * @return void
+	 */
+	public function test_get_languages_falls_back_to_home_when_untranslated(): void {
+		Functions\when( 'get_home_url' )->alias( static fn ( $id ) => "https://blog{$id}.tld/" );
+
+		$en = $this->blog( 'en_US', '', 1 );
+		$de = $this->blog( 'de_DE', '', 2 );
+
+		$result = $this->invoke( 'get_languages', $this->collection( [ $en, $de ], $en ), Mockery::mock( OptionsInterface::class ) );
+
+		$this->assertSame(
+			[
+				[
+					'label' => 'EN',
+					'lang' => 'en',
+					'url' => '',
+					'current' => true,
+				],
+				[
+					'label' => 'DE',
+					'lang' => 'de',
+					'url' => 'https://blog2.tld/',
+					'current' => false,
+				],
+			],
+			$result,
+		);
+	}
+
+	/**
+	 * Verify nothing is collected when the only language is the current one.
+	 *
+	 * @return void
+	 */
+	public function test_get_languages_empty_without_other_languages(): void {
+		$en = $this->blog( 'en_US', '' );
+
+		$result = $this->invoke( 'get_languages', $this->collection( [ $en ], $en ), Mockery::mock( OptionsInterface::class ) );
+
+		$this->assertSame( [], $result );
+	}
+
+	/**
+	 * Verify render() wraps the current language and links in a labelled nav.
+	 *
+	 * @return void
+	 */
+	public function test_render_outputs_switcher_markup(): void {
+		$languages = [
+			[
+				'label' => 'EN',
+				'lang' => 'en',
+				'url' => '',
+				'current' => true,
+			],
+			[
+				'label' => 'DE',
+				'lang' => 'de',
+				'url' => 'https://example.tld/de/',
+				'current' => false,
+			],
+		];
+
+		$this->assertSame(
 			'<nav class="language-switcher" aria-label="Languages">'
 			. '<span class="current" aria-current="page" lang="en">EN</span>'
 			. '<a href="https://example.tld/de/" hreflang="de">DE</a>'
 			. '</nav>',
+			$this->invoke( 'render', $languages ),
 		);
-
-		Msls::display();
 	}
 
 	/**
-	 * Verify display() skips languages that have no translation for the content.
+	 * Verify display() renders nothing when the MSLS plugin is inactive.
 	 *
 	 * @return void
 	 */
-	public function test_display_skips_untranslated_languages(): void {
-		$en = $this->blog( 'en_US', '' );
-		$de = $this->blog( 'de_DE', 'https://example.tld/de/' );
-		$fr = $this->blog( 'fr_FR', '' );
-
-		$this->stub_collection( [ $en, $de, $fr ], $en );
-
-		$this->expectOutputString(
-			'<nav class="language-switcher" aria-label="Languages">'
-			. '<span class="current" aria-current="page" lang="en">EN</span>'
-			. '<a href="https://example.tld/de/" hreflang="de">DE</a>'
-			. '</nav>',
-		);
-
-		Msls::display();
-	}
-
-	/**
-	 * Verify display() renders nothing when no other language has a translation.
-	 *
-	 * @return void
-	 */
-	public function test_display_renders_nothing_without_other_languages(): void {
-		$en = $this->blog( 'en_US', '' );
-
-		$this->stub_collection( [ $en ], $en );
-
+	public function test_display_renders_nothing_when_plugin_inactive(): void {
 		$this->expectOutputString( '' );
 
 		Msls::display();


### PR DESCRIPTION
## Summary

Fixes the language switcher disappearing on single posts (reported on two posts that are translations of each
other), and makes it always offer the full set of languages.

## Bug

`Integration\Msls::get_languages()` resolved URLs with `msls_options()`, which returns `MslsOptions::instance()` —
the **generic** cached singleton. It is not request-aware, so `has_value( $language )` was always false for a post
and `MslsBlog::get_url()` returned `null`. Every other language was then skipped, so the switcher rendered nothing
on posts (it only appeared on the front page, which short-circuits via `is_front_page()`).

## Fix

- Resolve URLs with **`MslsOptions::create()`** — the request-aware factory MSLS itself uses (it returns
  `MslsOptionsPost( get_queried_object_id() )` on a single post), so a post's translation URL resolves correctly.
- **Always show every language.** When a language has no translation for the current content, link it to that
  language's home page (`get_home_url( $blog_id )`) instead of hiding it. The switcher only renders nothing when
  there is genuinely no other language.

`get_languages()` now takes the collection and options as parameters (injected in `display()`), which also makes
the data logic unit-testable without the static factory.

## Verification

- `composer cs` (PHPCS Apermo), `composer analyse` (PHPStan level 5), 85 unit tests — all pass.
- Live on a DDEV multisite with MSLS active: a single post (HTTP 200) that previously rendered **no** switcher now
  renders `<span class="current" aria-current="page" lang="de">DE</span>` + `<a href="…" hreflang="en">EN</a>`
  (the EN link falling back to the site home where no translation exists). The homepage is unchanged.

Bumps version to 1.5.3.