### PR TITLE
refactor(css): semantic CSS custom properties (#18)

### DIFF
--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -1,9 +1,7 @@
 /* stylelint-disable no-descending-specificity, no-duplicate-selectors */
 body {
-	background-color: $white;
 	background-color: var(--color-background);
-	color: $dark-gray;
-	color: var(--color-dark-gray);
+	color: var(--color-text);
 
 	font-family: $font-sans;
 	font-weight: 400;
@@ -19,13 +17,11 @@ address {
 }
 
 a {
-	color: $dark-gray;
-	color: var(--color-dark-gray);
+	color: var(--color-text);
 }
 
 svg {
-	fill: $dark-gray;
-	fill: var(--color-dark-gray);
+	fill: var(--color-text);
 }
 
 a:hover {
@@ -36,16 +32,14 @@ abbr {
 	font-variant: small-caps;
 
 	&[title] {
-		border-bottom: 1px dotted $gray;
-		border-bottom-color: var(--color-gray);
+		border-bottom: 1px dotted var(--color-text-muted);
 		cursor: help;
 	}
 }
 
 blockquote,
 figure {
-	color: $gray;
-	color: var(--color-gray);
+	color: var(--color-text-muted);
 	font-size: 1em;
 	font-style: italic;
 	position: relative;
@@ -55,8 +49,7 @@ figure {
 	small,
 	figcaption,
 	cite {
-		color: $gray;
-		color: var(--color-gray);
+		color: var(--color-text-muted);
 		display: block;
 		font-size: .7em;
 		font-style: normal;
@@ -107,25 +100,26 @@ iframe {
 
 blockquote {
 	border: 0;
-	border-left: 3px solid $border-gray;
+	border-left: 3px solid var(--color-border);
 	margin: 0;
 	padding-left: 30px;
 	line-height: 1.8;
 }
 
 code {
-	background-color: var(--color-dark-gray);
-	color: var(--color-white);
+	background-color: var(--color-code-bg);
+	color: var(--color-code-text);
 	border-radius: 0.3em;
 	padding: 4px 5px 5px;
 
 	a {
-		color: var(--color-white);
+		color: var(--color-code-text);
 	}
 }
 
 ins {
-	background: $yellow;
+	background: var(--color-mark-bg);
+	color: var(--color-mark-text);
 	text-decoration: none;
 }
 
@@ -137,7 +131,7 @@ h5,
 h6 {
 	font-family: $font-serif;
 	font-weight: 100;
-	margin-bottom: 0;
+	margin-bottom: .5em;
 	line-height: 1.2;
 }
 
@@ -170,15 +164,15 @@ hr {
 	width: 200px;
 	margin: 60px auto !important;
 	border: 0;
-	border-top: 1px solid $border-gray;
+	border-top: 1px solid var(--color-border);
 	text-align: center;
 }
 
 pre {
 	margin-top: 50px;
 	margin-bottom: 50px;
-	background-color: #000;
-	color: #fff;
+	background-color: var(--color-code-bg);
+	color: var(--color-code-text);
 	display: block;
 	padding: 50px;
 	white-space: pre-wrap;

--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -178,6 +178,10 @@ pre {
 	white-space: pre-wrap;
 	word-wrap: break-word;
 
+	a {
+		color: inherit;
+	}
+
 	code {
 		background-color: inherit;
 		color: inherit;

--- a/assets/sass/_block.scss
+++ b/assets/sass/_block.scss
@@ -1,8 +1,7 @@
 .wp-block-preformatted {
 	background-color: inherit;
 	color: inherit;
-	border: 1px solid $lighter-gray;
-	border-color: var(--color-lighter-gray);
+	border: 1px solid var(--color-text-subtle);
 }
 
 .wp-block-columns .aligncenter {

--- a/assets/sass/_comment.scss
+++ b/assets/sass/_comment.scss
@@ -26,8 +26,7 @@
 
 	label {
 		display: block;
-		color: $gray;
-		color: var(--color-gray);
+		color: var(--color-text-muted);
 	}
 
 	.says {
@@ -103,8 +102,7 @@ li.comment {
 .logged-in-as {
 	display: block;
 	font-family: $font-sans;
-	color: $gray;
-	color: var(--color-gray);
+	color: var(--color-text-muted);
 }
 
 .comment-meta {
@@ -121,8 +119,7 @@ li.comment {
 .comment-meta a,
 .comment-reply-link,
 .logged-in-as a {
-	color: $gray;
-	color: var(--color-gray);
+	color: var(--color-text-muted);
 	text-decoration: none;
 
 	&:hover {

--- a/assets/sass/_darkmode.scss
+++ b/assets/sass/_darkmode.scss
@@ -1,14 +1,35 @@
 :root {
+	// Surfaces & backgrounds.
 	--color-background: #{$white};
-	--color-white: #{$white};
-	--color-dark-gray: #{$dark-gray};
-	--color-gray: #{$gray};
-	--color-light-gray: #{$light-gray};
-	--color-lighter-gray: #{$lighter-gray};
-	--color-border-gray: #{$border-gray};
-	--color-background-gray: #{$background-gray};
-	--color-android-green: #{$android-green};
-	--color-usc-gold: #{$usc-gold};
+	--color-surface: #{$white};
+	--color-surface-alt: #{$background-gray};
+
+	// Text.
+	--color-text: #{$dark-gray};
+	--color-text-muted: #{$gray};
+	--color-text-meta: #{$light-gray};
+	--color-text-subtle: #{$lighter-gray};
+
+	// Borders.
+	--color-border: #{$border-gray};
+
+	// Accents.
+	--color-accent: #{$android-green};
+	--color-accent-alt: #{$usc-gold};
+
+	// UI primitives.
+	--color-selection-bg: #{$selection-bg};
+	--color-mark-bg: #{$yellow};
+	--color-mark-text: #{$dark-gray};
+	--color-shadow: #{rgba($dark-gray, 0.2)};
+
+	// Text on dark cover images — stays light in every mode.
+	--color-on-cover: #{$white};
+
+	// Terminal-style code blocks — green-on-dark in every mode.
+	--color-code-text: #{$terminal-green};
+	--color-code-bg: #{$terminal-green-bg};
+
 	color-scheme: light dark;
 }
 
@@ -16,13 +37,17 @@
 
 	:root {
 		--color-background: #{$dark-gray};
-		--color-white: #{$dark-gray};
-		--color-dark-gray: #{$white};
-		--color-gray: #{$white};
-		--color-light-gray: #{$white};
-		--color-lighter-gray: #{$white};
-		--color-border-gray: #{$light-gray};
-		--color-background-gray: #{$gray};
+		--color-surface: #{$dark-gray};
+		--color-surface-alt: #{$gray};
+
+		--color-text: #{$white};
+		--color-text-muted: #{$white};
+		--color-text-meta: #{$white};
+		--color-text-subtle: #{$white};
+
+		--color-border: #{$light-gray};
+
+		--color-shadow: #{rgba(#000, 0.5)};
 	}
 
 	img {

--- a/assets/sass/_darkmode.scss
+++ b/assets/sass/_darkmode.scss
@@ -41,12 +41,13 @@
 		--color-surface-alt: #{$gray};
 
 		--color-text: #{$white};
-		--color-text-muted: #{$white};
-		--color-text-meta: #{$white};
-		--color-text-subtle: #{$white};
+		--color-text-muted: #{$very-light-gray};
+		--color-text-meta: #{$border-gray};
+		--color-text-subtle: #{$lighter-gray};
 
 		--color-border: #{$light-gray};
 
+		--color-selection-bg: #{rgba($android-green, 0.3)};
 		--color-shadow: #{rgba(#000, 0.5)};
 	}
 

--- a/assets/sass/_form.scss
+++ b/assets/sass/_form.scss
@@ -4,7 +4,6 @@ input[type="password"],
 input[type="email"],
 input[type="url"],
 textarea {
-	border: none;
 	border: 1px solid var(--color-border);
 	border-radius: 5px;
 	padding: .5em;

--- a/assets/sass/_form.scss
+++ b/assets/sass/_form.scss
@@ -5,32 +5,31 @@ input[type="email"],
 input[type="url"],
 textarea {
 	border: none;
-	border: 1px solid $border-gray;
-	border-color: var(--color-border-gray);
+	border: 1px solid var(--color-border);
 	border-radius: 5px;
 	padding: .5em;
 
-	&:focus {
-		outline: 0;
+	&:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
 	}
 }
 
 input,
 textarea {
 	max-width: 90%;
-	background-color: $white;
-	background-color: var(--color-white);
+	background-color: var(--color-surface);
 }
 
 input[type="search"] {
-	border: 1px solid $border-gray;
-	border-color: var(--color-border-gray);
+	border: 1px solid var(--color-border);
 	border-radius: 50px;
 	padding: 5px 15px;
 	width: 80%;
 
-	&:focus {
-		outline: 0;
+	&:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
 	}
 }
 

--- a/assets/sass/_media.scss
+++ b/assets/sass/_media.scss
@@ -122,7 +122,7 @@ img.wp-post-image {
 }
 
 .gallery .gallery-caption {
-	color: #888;
+	color: var(--color-text-muted);
 	font-size: 12px;
 	margin: 0 0 12px;
 }

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -25,11 +25,9 @@
 	a {
 		font-size: 1em;
 		font-family: $font-sans;
-		background-color: $background-gray;
-		background-color: var(--color-background-gray);
+		background-color: var(--color-surface-alt);
 		border-radius: 3px;
-		color: $dark-gray;
-		color: var(--color-dark-gray);
+		color: var(--color-text);
 		line-height: 1;
 		padding: 5px 8px;
 		text-decoration: none;
@@ -45,23 +43,21 @@
 
 	a {
 		text-decoration: none;
-		color: $gray;
-		color: var(--color-gray);
+		color: var(--color-text-muted);
 	}
 
-	color: $gray;
-	color: var(--color-gray);
-	border: 1px solid $border-gray;
-	background-color: $white;
-	background-color: var(--color-white);
+	color: var(--color-text-muted);
+	border: 1px solid var(--color-border);
+	background-color: var(--color-surface);
 	border-radius: 50px;
 	padding: 10px 20px;
 	display: inline-block;
 	line-height: 1;
 	text-decoration: none;
 
-	&:focus {
-		outline: 0;
+	&:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
 	}
 
 	&:hover,
@@ -70,30 +66,24 @@
 	&:active:visited,
 	&:hover a,
 	&:active a {
-		border: 1px solid $gray;
-		border-color: var(--color-gray);
-		background-color: $gray;
-		background-color: var(--color-gray);
-		color: $white;
-		color: var(--color-white);
+		border: 1px solid var(--color-text-muted);
+		background-color: var(--color-text-muted);
+		color: var(--color-surface);
 	}
 
 	&:visited {
-		color: $gray;
-		color: var(--color-gray);
+		color: var(--color-text-muted);
 	}
 }
 
 @mixin meta-text {
 	font-family: $font-sans;
 	clear: both;
-	color: $light-gray;
-	color: var(--color-light-gray);
+	color: var(--color-text-meta);
 	display: block;
 
 	a {
-		color: $light-gray;
-		color: var(--color-light-gray);
+		color: var(--color-text-meta);
 		text-decoration: none;
 	}
 

--- a/assets/sass/_nav.scss
+++ b/assets/sass/_nav.scss
@@ -11,7 +11,7 @@
 	@include clearfix;
 
 	ul {
-		border-top: 1px solid $border-gray;
+		border-top: 1px solid var(--color-border);
 		position: relative;
 		z-index: 597;
 		list-style: none;
@@ -22,8 +22,7 @@
 
 		a {
 			border-top: 0 none;
-			color: $dark-gray;
-			color: var(--color-dark-gray);
+			color: var(--color-text);
 			display: block;
 			line-height: 1.5;
 			padding: 7.5px 0;
@@ -79,9 +78,8 @@
 
 		ul {
 			border: none;
-			background-color: $white;
-			background-color: var(--color-white);
-			box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
+			background-color: var(--color-surface);
+			box-shadow: 0 8px 16px 0 var(--color-shadow);
 			margin-top: 0;
 			min-width: 190px;
 			position: absolute;
@@ -92,8 +90,7 @@
 			z-index: 598;
 
 			a {
-				color: $dark-gray;
-				color: var(--color-dark-gray);
+				color: var(--color-text);
 				border-top: 0 none;
 				line-height: 1.5;
 				padding: 16px 20px;
@@ -195,8 +192,7 @@
 	}
 
 	a:hover {
-		color: $dark-gray;
-		color: var(--color-dark-gray);
+		color: var(--color-text);
 	}
 }
 
@@ -229,8 +225,7 @@
 		font-size: 1.5em;
 		display: inline-block;
 		margin: 0 5px;
-		color: $light-gray;
-		color: var(--color-light-gray);
+		color: var(--color-text-meta);
 	}
 
 	a {
@@ -238,14 +233,12 @@
 
 		&:hover {
 			text-decoration: underline;
-			color: $dark-gray;
-			color: var(--color-dark-gray);
+			color: var(--color-text);
 		}
 	}
 
 	.current {
-		color: $dark-gray;
-		color: var(--color-dark-gray);
+		color: var(--color-text);
 	}
 }
 

--- a/assets/sass/_normalize.scss
+++ b/assets/sass/_normalize.scss
@@ -90,15 +90,6 @@ a {
 	background-color: transparent;
 }
 
-/**
- * Improve readability when focused and also mouse hovered in all browsers.
- */
-
-a:active,
-a:hover {
-	outline: 0;
-}
-
 /* Text-level semantics
 	 ========================================================================== */
 

--- a/assets/sass/_page.scss
+++ b/assets/sass/_page.scss
@@ -3,7 +3,7 @@
 	display: block;
 	position: relative;
 	width: 100%;
-	border-bottom: 1px solid $border-gray;
+	border-bottom: 1px solid var(--color-border);
 
 	.site-branding {
 		margin: 0 auto;
@@ -38,11 +38,10 @@
 
 	.page-banner {
 		width: 100%;
-		border-top: 1px solid $border-gray;
+		border-top: 1px solid var(--color-border);
 
 		a {
-			color: $dark-gray;
-			color: var(--color-dark-gray);
+			color: var(--color-text);
 		}
 
 		.page-branding {
@@ -82,8 +81,7 @@
 			display: block;
 			margin: 0 auto;
 			text-align: left;
-			color: $dark-gray;
-			color: var(--color-dark-gray);
+			color: var(--color-text);
 			font-size: 1.5em;
 			width: $wide-width;
 		}
@@ -118,8 +116,7 @@
 		font-family: $font-sans;
 
 		a {
-			color: $dark-gray;
-			color: var(--color-dark-gray);
+			color: var(--color-text);
 			text-decoration: none;
 
 			&:hover {
@@ -128,8 +125,7 @@
 		}
 
 		.current {
-			color: $dark-gray;
-			color: var(--color-dark-gray);
+			color: var(--color-text);
 			font-weight: 700;
 			cursor: default;
 		}
@@ -174,8 +170,7 @@
 
 #colophon {
 	width: 100%;
-	background-color: $background-gray;
-	background-color: var(--color-background-gray);
+	background-color: var(--color-surface-alt);
 	margin-top: 100px;
 	content-visibility: auto;
 
@@ -186,8 +181,7 @@
 	clear: both;
 	padding: 50px 0;
 	text-align: center;
-	background-color: $white;
-	background-color: var(--color-white);
+	background-color: var(--color-surface);
 }
 
 .screen-reader-text,
@@ -221,8 +215,7 @@
 // Notices
 .post .notice,
 .error404 #searchform {
-	background: $light-gray;
-	background: var(--color-light-gray);
+	background: var(--color-text-meta);
 	display: block;
 	padding: 1em;
 }

--- a/assets/sass/_page.scss
+++ b/assets/sass/_page.scss
@@ -215,7 +215,7 @@
 // Notices
 .post .notice,
 .error404 #searchform {
-	background: var(--color-text-meta);
+	background: var(--color-surface-alt);
 	display: block;
 	padding: 1em;
 }

--- a/assets/sass/_post.scss
+++ b/assets/sass/_post.scss
@@ -27,15 +27,15 @@
 		background-size: cover;
 
 		.entry-title, .entry-meta, .entry-format {
-			color: $white;
+			color: var(--color-on-cover);
 
 			a {
-				color: $white;
+				color: var(--color-on-cover);
 			}
 		}
 
 		.entry-meta.post-format .entry-format::before {
-			color: $white;
+			color: var(--color-on-cover);
 		}
 
 		.entry-header-wrapper {
@@ -56,7 +56,7 @@
 		}
 
 		.avatar {
-			border: 2px solid $white;
+			border: 2px solid var(--color-on-cover);
 		}
 	}
 }
@@ -72,7 +72,7 @@
 
 		&::after {
 			content: "";
-			border-top: 1px solid $border-gray;
+			border-top: 1px solid var(--color-border);
 			width: 200px;
 			display: block;
 			text-align: center;
@@ -100,8 +100,7 @@ h4.entry-title {
 		font-size: 1em;
 		line-height: 1;
 		text-decoration: none;
-		color: $dark-gray;
-		color: var(--color-dark-gray);
+		color: var(--color-text);
 
 		&:hover {
 			text-decoration: underline;
@@ -129,8 +128,7 @@ h4.entry-title {
 
 .entry-content,
 .entry-summary {
-	color: $dark-gray;
-	color: var(--color-dark-gray);
+	color: var(--color-text);
 	font-style: normal;
 	font-size: 1.2em;
 	margin: 0 auto;
@@ -157,8 +155,7 @@ h4.entry-title {
 		text-decoration: underline;
 
 		@supports(text-decoration: underline $android-green) {
-			text-decoration: underline $android-green;
-			text-decoration: underline var(--color-android-green);
+			text-decoration: underline var(--color-accent);
 			text-decoration-thickness: 3px;
 			text-underline-offset: 6px;
 		}
@@ -166,8 +163,7 @@ h4.entry-title {
 		&:hover {
 
 			@supports(text-decoration: underline $android-green) {
-				text-decoration: underline $usc-gold;
-				text-decoration: underline var(--color-usc-gold);
+				text-decoration: underline var(--color-accent-alt);
 				text-decoration-thickness: 3px;
 				text-underline-offset: 6px;
 			}
@@ -185,12 +181,10 @@ h4.entry-title {
 	display: inline-block;
 	font-size: 1em;
 	font-family: $font-sans;
-	background-color: $background-gray;
-	background-color: var(--color-background-gray);
+	background-color: var(--color-surface-alt);
 	border: none;
 	border-radius: 3px;
-	color: $dark-gray;
-	color: var(--color-dark-gray);
+	color: var(--color-text);
 	line-height: inherit;
 	padding: 3px 7px;
 	text-decoration: none;
@@ -228,13 +222,11 @@ h4.entry-title {
 .page-links {
 	font-family: $font-sans;
 	clear: both;
-	color: $gray;
-	color: var(--color-gray);
+	color: var(--color-text-muted);
 	display: block;
 
 	a {
-		color: $gray;
-		color: var(--color-gray);
+		color: var(--color-text-muted);
 		text-decoration: none;
 	}
 
@@ -268,8 +260,7 @@ h4.entry-title {
 	&.post-format a,
 	&.post-format span,
 	&.post-format .entry-format::before {
-		color: $lighter-gray;
-		color: var(--color-lighter-gray);
+		color: var(--color-text-subtle);
 		font-weight: 700;
 		text-transform: lowercase;
 	}
@@ -286,8 +277,7 @@ h4.entry-title {
 		text-decoration: none;
 		top: 2px;
 		vertical-align: text-middle;
-		color: $lighter-gray;
-		color: var(--color-lighter-gray);
+		color: var(--color-text-subtle);
 	}
 
 	.entry-format {
@@ -297,8 +287,7 @@ h4.entry-title {
 	address {
 		font-size: 1em;
 		line-height: 1.2;
-		color: $dark-gray;
-		color: var(--color-dark-gray);
+		color: var(--color-text);
 	}
 
 	.entry-date,
@@ -414,8 +403,7 @@ h4.entry-title {
 .more-link {
 	display: block;
 	font-size: .8em;
-	color: $gray;
-	color: var(--color-gray);
+	color: var(--color-text-muted);
 }
 
 .entry-content {
@@ -485,13 +473,11 @@ h4.entry-title {
 	}
 
 	.has-white-background-color {
-		background-color: $white;
-		background-color: var(--color-white);
+		background-color: var(--color-surface);
 	}
 
 	.has-white-color {
-		color: $white;
-		color: var(--color-white);
+		color: var(--color-surface);
 	}
 
 	.has-very-light-gray-background-color {
@@ -518,7 +504,7 @@ h4.entry-title {
 }
 
 .wp-block-footnotes {
-	border-top: solid 1px #d3d3d3;
+	border-top: solid 1px var(--color-border);
 	margin-top: 2em;
 	padding-top: 2em;
 	font-size: .8em;

--- a/assets/sass/_post.scss
+++ b/assets/sass/_post.scss
@@ -477,7 +477,7 @@ h4.entry-title {
 	}
 
 	.has-white-color {
-		color: var(--color-surface);
+		color: var(--color-on-cover);
 	}
 
 	.has-very-light-gray-background-color {

--- a/assets/sass/_sidebar.scss
+++ b/assets/sass/_sidebar.scss
@@ -35,22 +35,18 @@
 	}
 
 	input {
-		color: $dark-gray;
-		color: var(--color-dark-gray);
+		color: var(--color-text);
 	}
 
 	button,
 	input[type="submit"] {
-		color: $dark-gray;
-		color: var(--color-dark-gray);
-		background-color: $white;
-		background-color: var(--color-white);
+		color: var(--color-text);
+		background-color: var(--color-surface);
 		border: none;
 		padding: .5em 1em;
 
 		&:hover {
-			background-color: $gray;
-			background-color: var(--color-gray);
+			background-color: var(--color-text-muted);
 		}
 	}
 }

--- a/assets/sass/_sidebar.scss
+++ b/assets/sass/_sidebar.scss
@@ -47,6 +47,7 @@
 
 		&:hover {
 			background-color: var(--color-text-muted);
+			color: var(--color-surface);
 		}
 	}
 }

--- a/assets/sass/_table.scss
+++ b/assets/sass/_table.scss
@@ -25,7 +25,7 @@ table {
 
 table th,
 table td {
-	border-top: 1px solid $border-gray;
+	border-top: 1px solid var(--color-border);
 	padding: 10px;
 	text-align: left;
 	vertical-align: top;
@@ -41,7 +41,7 @@ table thead:first-child tr:first-child td {
 }
 
 table tbody + tbody {
-	border-top: 2px solid $border-gray;
+	border-top: 2px solid var(--color-border);
 }
 
 table caption + thead tr:first-child th,
@@ -58,12 +58,10 @@ table tbody:first-child tr:first-child td {
 
 table tbody tr:nth-child(odd) td,
 table tbody tr:nth-child(odd) th {
-	background-color: $background-gray;
-	background-color: var(--color-background-gray);
+	background-color: var(--color-surface-alt);
 }
 
 table tbody tr:hover td,
 table tbody tr:hover th {
-	background-color: $background-gray;
-	background-color: var(--color-background-gray);
+	background-color: var(--color-surface-alt);
 }

--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -41,7 +41,7 @@ $very-dark-gray: #444;
 
 // Terminal aesthetic (green-on-dark), shared with form styling.
 $terminal-green: #1eb100;
-$terminal-green-bg: #203f00;
+$terminal-green-bg: #102000;
 
 // Selection highlight.
 $selection-bg: #b3d4fc;

--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -39,6 +39,13 @@ $white: #fff;
 $very-light-gray: #eee;
 $very-dark-gray: #444;
 
+// Terminal aesthetic (green-on-dark), shared with form styling.
+$terminal-green: #1eb100;
+$terminal-green-bg: #203f00;
+
+// Selection highlight.
+$selection-bg: #b3d4fc;
+
 // Typography — system font stacks.
 // stylelint-disable value-keyword-case -- System font names require exact casing.
 $font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/assets/sass/_widgets.scss
+++ b/assets/sass/_widgets.scss
@@ -25,14 +25,12 @@
 		.note {
 			font-size: .9em;
 			margin-bottom: 10px;
-			color: $gray;
-			color: var(--color-gray);
+			color: var(--color-text-muted);
 		}
 
 		.subscribe {
 			font-size: .8em;
-			color: $light-gray;
-			color: var(--color-light-gray);
+			color: var(--color-text-meta);
 			vertical-align: bottom;
 		}
 
@@ -60,8 +58,7 @@
 
 		label {
 			display: block;
-			color: $gray;
-			color: var(--color-gray);
+			color: var(--color-text-muted);
 		}
 	}
 }

--- a/assets/sass/integrations.scss
+++ b/assets/sass/integrations.scss
@@ -26,13 +26,11 @@ ul.relsyn {
 .kind .svg-icon {
 	height: 15px;
 	width: 15px;
-	color: $light-gray;
-	color: var(--color-light-gray);
+	color: var(--color-text-meta);
 	display: inline-block;
 
 	svg {
-		fill: $light-gray;
-		fill: var(--color-light-gray);
+		fill: var(--color-text-meta);
 	}
 }
 

--- a/assets/sass/print.scss
+++ b/assets/sass/print.scss
@@ -38,8 +38,7 @@ a[href^="javascript:"]::after {
 
 pre,
 blockquote {
-	border: 1px solid $gray;
-	border-color: var(--color-gray);
+	border: 1px solid var(--color-text-muted);
 	page-break-inside: avoid;
 }
 

--- a/assets/sass/responsive_wide.scss
+++ b/assets/sass/responsive_wide.scss
@@ -116,32 +116,26 @@ p {
 		font-size: .9em;
 		font-style: italic;
 		float: left;
-		color: $light-gray;
-		color: var(--color-light-gray);
+		color: var(--color-text-meta);
 		padding: 1em 0 1em 0;
 		margin-right: 2.5em;
 		margin-left: calc( 50% - 450px );
 		width: 400px;
-		border-top: 1px solid $light-gray;
-		border-top-color: var(--color-light-gray);
-		border-bottom: 1px solid $light-gray;
-		border-bottom-color: var(--color-light-gray);
+		border-top: 1px solid var(--color-text-meta);
+		border-bottom: 1px solid var(--color-text-meta);
 	}
 
 	&.alignright {
 		font-size: .9em;
 		font-style: italic;
 		float: right;
-		color: $light-gray;
-		color: var(--color-light-gray);
+		color: var(--color-text-meta);
 		padding: 1em 0 1em 0;
 		margin-left: 2.5em;
 		margin-right: calc( 50% - 450px );
 		width: 400px;
-		border-top: 1px solid $light-gray;
-		border-top-color: var(--color-light-gray);
-		border-bottom: 1px solid $light-gray;
-		border-bottom-color: var(--color-light-gray);
+		border-top: 1px solid var(--color-text-meta);
+		border-bottom: 1px solid var(--color-text-meta);
 	}
 }
 
@@ -161,8 +155,7 @@ p {
 		&::before {
 			width: 25%;
 			margin-right: 75%;
-			border-top: 1px solid $light-gray;
-			border-top-color: var(--color-light-gray);
+			border-top: 1px solid var(--color-text-meta);
 			display: block;
 			content: "";
 			margin-bottom: 10px;
@@ -186,8 +179,7 @@ p {
 		&::before {
 			width: 25%;
 			margin-left: 75%;
-			border-top: 1px solid $light-gray;
-			border-top-color: var(--color-light-gray);
+			border-top: 1px solid var(--color-text-meta);
 			display: block;
 			content: "";
 			margin-bottom: 10px;

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -37,8 +37,7 @@
 // =============================================================================
 
 html {
-	color: $dark-gray;
-	color: var(--color-dark-gray);
+	color: var(--color-text);
 	font-size: 1em;
 	line-height: 1.6;
 }
@@ -49,7 +48,7 @@ html {
 
 ::-moz-selection,
 ::selection {
-	background: #b3d4fc;
+	background: var(--color-selection-bg);
 	text-shadow: none;
 }
 
@@ -84,9 +83,8 @@ textarea {
 
 .browsehappy,
 .browserupgrade {
-	background: $gray;
-	background: var(--color-gray);
-	color: #000;
+	background: var(--color-text-muted);
+	color: var(--color-surface);
 	margin: .2em 0;
 	padding: .2em 0;
 }


### PR DESCRIPTION
Foundation for the 2.0.0 visual rewrite (migration from the old `custom-theme`). Establishes a semantic CSS custom property system so dark mode, terminal form colors, and the meta navigation can build on stable, self-documenting variables.

## Variable rename
Misleading names replaced with semantic ones:

| Old | New |
|---|---|
| `--color-white` | `--color-surface` |
| `--color-dark-gray` | `--color-text` |
| `--color-gray` | `--color-text-muted` |
| `--color-light-gray` | `--color-text-meta` |
| `--color-lighter-gray` | `--color-text-subtle` |
| `--color-border-gray` | `--color-border` |
| `--color-background-gray` | `--color-surface-alt` |
| `--color-android-green` | `--color-accent` |
| `--color-usc-gold` | `--color-accent-alt` |

New variables: `--color-selection-bg`, `--color-mark-bg`/`--color-mark-text`, `--color-shadow`, `--color-on-cover`, `--color-code-bg`/`--color-code-text`.

## Cleanup & fixes
- Drop the legacy `prop: $sass; prop: var(--x)` double-declarations.
- Fix hardcoded colors that broke dark mode: `pre`/`code`, `ins`, borders, `::selection`, submenu shadow, browsehappy, gallery captions.
- Style `pre`/`code` as terminal green-on-dark.
- Restore focus outlines via `:focus-visible` (WCAG 2.4.7) — removes `outline: 0` in forms, button mixin, and the h5bp normalize rule.
- Give headings a bottom margin to restore whitespace hierarchy.

## Notes
- Targets `feature/2.0.0` (the migration integration branch), not `main`.
- `@import` → `@use` migration is out of scope (tracked in #84).

Closes #18