### PR TITLE
feat(css): terminal-style form fields

### DIFF
--- a/assets/sass/_darkmode.scss
+++ b/assets/sass/_darkmode.scss
@@ -30,6 +30,11 @@
 	--color-code-text: #{$terminal-green};
 	--color-code-bg: #{$terminal-green-bg};
 
+	// Terminal-style form fields — green-on-dark in every mode.
+	--color-form-text: #{$terminal-green};
+	--color-form-bg: #{$terminal-green-bg};
+	--color-form-border: #{$terminal-green};
+
 	color-scheme: light dark;
 }
 

--- a/assets/sass/_form.scss
+++ b/assets/sass/_form.scss
@@ -19,6 +19,9 @@ textarea {
 input,
 textarea {
 	max-width: 90%;
+}
+
+input {
 	background-color: var(--color-surface);
 }
 

--- a/assets/sass/_form.scss
+++ b/assets/sass/_form.scss
@@ -4,9 +4,11 @@ input[type="password"],
 input[type="email"],
 input[type="url"],
 textarea {
-	border: 1px solid var(--color-border);
+	border: 1px solid var(--color-form-border);
 	border-radius: 5px;
 	padding: .5em;
+	background-color: var(--color-form-bg);
+	color: var(--color-form-text);
 
 	&:focus-visible {
 		outline: 2px solid var(--color-accent);
@@ -21,10 +23,12 @@ textarea {
 }
 
 input[type="search"] {
-	border: 1px solid var(--color-border);
+	border: 1px solid var(--color-form-border);
 	border-radius: 50px;
 	padding: 5px 15px;
 	width: 80%;
+	background-color: var(--color-form-bg);
+	color: var(--color-form-text);
 
 	&:focus-visible {
 		outline: 2px solid var(--color-accent);


### PR DESCRIPTION
Closes #24.

## What
Adds the green terminal aesthetic to form fields, in the `--color-*` custom-property convention established in #97 (rather than the issue's literal `--green-color` names).

- New semantic vars in `_darkmode.scss` `:root`, mirroring the existing `--color-code-*` terminal-code vars (green-on-dark in **every** mode):
  - `--color-form-text` = $terminal-green
  - `--color-form-bg` = $terminal-green-bg
  - `--color-form-border` = $terminal-green
- Restyled `input[type=text|password|email|url|search]` and `textarea` to use them (text/bg/border). Focus ring (`--color-accent`) unchanged.

## Scope notes
- **Fields only.** I deliberately left the site-wide `button` mixin untouched — terminal-coloring every button (nav/CTA/wp-block-button) is a broader visual change than #24 implies. Happy to extend to form submit/search buttons if you want.
- The source `../custom-theme` wasn't available, so colors are adapted from this theme's existing terminal palette (which already powers code blocks) rather than ported verbatim.
- Contrast: reuses the AA-safe terminal palette (#1eb100 on #102000) from the #97 round-2 fix.

Built (`build:sass`) and stylelint-clean locally; compiled CSS is gitignored.