### PR TITLE
feat(theme): radial gradient body + meta-nav scaffold

### DIFF
--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable no-descending-specificity, no-duplicate-selectors */
 body {
-	background-color: var(--color-background);
+	background: var(--color-body-bg) var(--color-background) fixed;
 	color: var(--color-text);
 
 	font-family: $font-sans;

--- a/assets/sass/_darkmode.scss
+++ b/assets/sass/_darkmode.scss
@@ -1,6 +1,7 @@
 :root {
 	// Surfaces & backgrounds.
 	--color-background: #{$white};
+	--color-body-bg: radial-gradient(circle at center, #eee 0%, #ddd 100%);
 	--color-surface: #{$white};
 	--color-surface-alt: #{$background-gray};
 
@@ -42,6 +43,7 @@
 
 	:root {
 		--color-background: #{$dark-gray};
+		--color-body-bg: radial-gradient(circle at center, #222 0%, #111 100%);
 		--color-surface: #{$dark-gray};
 		--color-surface-alt: #{$gray};
 

--- a/assets/sass/_meta-navigation.scss
+++ b/assets/sass/_meta-navigation.scss
@@ -1,0 +1,6 @@
+.meta-navigation {
+	display: flex;
+	justify-content: flex-end;
+	margin: 0 auto;
+	padding-top: .75rem;
+}

--- a/assets/sass/responsive_default.scss
+++ b/assets/sass/responsive_default.scss
@@ -2,6 +2,7 @@
 @import "mixins";
 
 .site-navigation,
+.site-header .meta-navigation,
 .site-header .site-branding,
 .site-header .page-banner #page-title,
 .site-header .page-banner #page-description,

--- a/assets/sass/responsive_narrow.scss
+++ b/assets/sass/responsive_narrow.scss
@@ -7,6 +7,7 @@ html {
 }
 
 #sidebar,
+.site-header .meta-navigation,
 .site-header .site-branding,
 .site-header .page-banner #page-description,
 .site-header .page-banner #page-title,

--- a/assets/sass/responsive_wide.scss
+++ b/assets/sass/responsive_wide.scss
@@ -4,6 +4,7 @@
 
 #sidebar,
 .site-navigation,
+.site-header .meta-navigation,
 .site-header .site-branding,
 .site-header .page-banner #page-title,
 .site-header .page-banner #page-description,

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -98,6 +98,7 @@ textarea {
 @import "post";
 @import "nav";
 @import "logo";
+@import "meta-navigation";
 @import "table";
 @import "media";
 @import "sidebar";

--- a/header.php
+++ b/header.php
@@ -36,6 +36,18 @@ wp_body_open();
 	do_action( 'sovereignty_before' );
 	?>
 	<header id="site-header" class="site-header">
+		<nav id="meta-navigation" class="meta-navigation" aria-label="<?php esc_attr_e( 'Site tools', 'sovereignty' ); ?>">
+			<?php
+			/**
+			 * Fires inside the meta navigation bar.
+			 *
+			 * Reserved for header tools such as search and the color-scheme
+			 * toggle.
+			 */
+			do_action( 'sovereignty_meta_navigation' );
+			?>
+		</nav><!-- #meta-navigation -->
+
 		<div class="site-branding">
 			<?php
 			if ( has_custom_logo() ) {


### PR DESCRIPTION
Split out the parts of the color-scheme work that are ready to land, separate from the dark-mode toggle (which needs more iteration and will be re-added later).

## Included
- **Radial gradient body background** — restores the original theme's `--color-body-bg` (`#eee→#ddd` light, `#222→#111` dark), giving content surfaces depth against the page.
- **`#meta-navigation` scaffold** — a header region aligned to the content width at every breakpoint, with a `sovereignty_meta_navigation` action hook. Empty for now; reserved for header tools (search modal #23, the color-scheme toggle #21).

## Not included
The dark-mode toggle (radiogroup/disclosure UI, `darkmode-switch.svg`, color-scheme JS/CSS, the head init script, and the forced-mode `_darkmode.scss` class refactor) stays out — it remains on `feat/issue-21-darkmode-toggle` / PR #100 for rework.

## Verification
Build, Stylelint, PHPCS, PHPStan all pass. Verified in DDEV: the gradient renders in light and dark, the meta-nav scaffold is present (empty, hook-ready) and the header layout is intact.

Targets `feature/2.0.0`.