### PR TITLE
feat(theme): terminal-chrome content separator

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -35,6 +35,7 @@ get_header(); ?>
 						 * If you want to overload this in a child theme then include a file
 						 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 						 */
+						Tags::separator();
 						get_template_part( 'templates/content', get_post_format( $post ) );
 						?>
 

--- a/assets/sass/_post.scss
+++ b/assets/sass/_post.scss
@@ -34,7 +34,7 @@
 			}
 		}
 
-		.entry-meta.post-format .entry-format::before {
+		.entry-format::before {
 			color: var(--color-on-cover);
 		}
 
@@ -231,21 +231,12 @@ h4.entry-title {
 	margin-top: 15px;
 	margin-bottom: 15px;
 
-	&.post-format {
-		padding: 0;
-		margin: 0;
-		margin-bottom: 10px;
+	.entry-format {
+		line-height: 1;
+		text-transform: capitalize;
 	}
 
-	&.post-format a,
-	&.post-format span,
-	&.post-format .entry-format::before {
-		color: var(--color-text-subtle);
-		font-weight: 700;
-		text-transform: lowercase;
-	}
-
-	&.post-format .entry-format::before {
+	.entry-format::before {
 		display: inline-block;
 		font: 400 1.1em Dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
 		-webkit-font-smoothing: antialiased;
@@ -257,11 +248,7 @@ h4.entry-title {
 		text-decoration: none;
 		top: 2px;
 		vertical-align: text-middle;
-		color: var(--color-text-subtle);
-	}
-
-	.entry-format {
-		line-height: 1;
+		color: var(--color-text-muted);
 	}
 
 	address {
@@ -271,7 +258,8 @@ h4.entry-title {
 	}
 
 	.entry-date,
-	.entry-duration {
+	.entry-duration,
+	.entry-format {
 		font-size: .8em;
 	}
 }
@@ -330,44 +318,48 @@ h4.entry-title {
 		display: none;
 	}
 
-	&.format-quote .post-format .entry-format::before {
+	&.format-quote .entry-format::before {
 		content: "\f122";
 	}
 
-	&.format-aside .post-format .entry-format::before {
+	&.format-aside .entry-format::before {
 		content: "\f123";
 	}
 
-	&.format-video .post-format .entry-format::before {
+	&.format-chat .entry-format::before {
+		content: "\f125";
+	}
+
+	&.format-video .entry-format::before {
 		content: "\f126";
 	}
 
-	&.format-audio .post-format .entry-format::before {
+	&.format-audio .entry-format::before {
 		content: "\f127";
 	}
 
-	&.format-image .post-format .entry-format::before,
-	&.format-photo .post-format .entry-format::before {
+	&.format-image .entry-format::before,
+	&.format-photo .entry-format::before {
 		content: "\f128";
 	}
 
-	&.format-gallery .post-format .entry-format::before {
+	&.format-gallery .entry-format::before {
 		content: "\f161";
 	}
 
-	&.format-link .post-format .entry-format::before {
+	&.format-link .entry-format::before {
 		content: "\f103";
 	}
 
-	&.format-status .post-format .entry-format::before {
+	&.format-status .entry-format::before {
 		content: "\f130";
 	}
 
-	&.format-standard .post-format .entry-format::before {
+	&.format-standard .entry-format::before {
 		content: "\f478";
 	}
 
-	&.type-page .post-format .entry-type-page::before {
+	&.type-page .entry-type-page::before {
 		content: "\f105";
 	}
 }

--- a/assets/sass/_post.scss
+++ b/assets/sass/_post.scss
@@ -317,51 +317,53 @@ h4.entry-title {
 	.sep:first-of-type {
 		display: none;
 	}
+}
 
-	&.format-quote .entry-format::before {
-		content: "\f122";
-	}
+// Post-format icons. Scoped to the format class (not a wrapper element) so they
+// apply to both <article> and the <aside> wrapper that aside/status/link use.
+.format-quote .entry-format::before {
+	content: "\f122";
+}
 
-	&.format-aside .entry-format::before {
-		content: "\f123";
-	}
+.format-aside .entry-format::before {
+	content: "\f123";
+}
 
-	&.format-chat .entry-format::before {
-		content: "\f125";
-	}
+.format-chat .entry-format::before {
+	content: "\f125";
+}
 
-	&.format-video .entry-format::before {
-		content: "\f126";
-	}
+.format-video .entry-format::before {
+	content: "\f126";
+}
 
-	&.format-audio .entry-format::before {
-		content: "\f127";
-	}
+.format-audio .entry-format::before {
+	content: "\f127";
+}
 
-	&.format-image .entry-format::before,
-	&.format-photo .entry-format::before {
-		content: "\f128";
-	}
+.format-image .entry-format::before,
+.format-photo .entry-format::before {
+	content: "\f128";
+}
 
-	&.format-gallery .entry-format::before {
-		content: "\f161";
-	}
+.format-gallery .entry-format::before {
+	content: "\f161";
+}
 
-	&.format-link .entry-format::before {
-		content: "\f103";
-	}
+.format-link .entry-format::before {
+	content: "\f103";
+}
 
-	&.format-status .entry-format::before {
-		content: "\f130";
-	}
+.format-status .entry-format::before {
+	content: "\f130";
+}
 
-	&.format-standard .entry-format::before {
-		content: "\f478";
-	}
+.format-standard .entry-format::before {
+	content: "\f478";
+}
 
-	&.type-page .entry-type-page::before {
-		content: "\f105";
-	}
+.type-page .entry-type-page::before {
+	content: "\f105";
 }
 
 .edit-link {

--- a/assets/sass/_post.scss
+++ b/assets/sass/_post.scss
@@ -61,9 +61,6 @@
 	}
 }
 
-#primary article:first-child {
-	margin-top: 50px;
-}
 
 h1.entry-title,
 h2.entry-title,
@@ -324,7 +321,7 @@ h4.entry-title {
 
 #primary article {
 	padding: 0;
-	margin-top: 100px;
+	margin-top: 0;
 	position: relative;
 
 	@include clearfix;

--- a/assets/sass/_post.scss
+++ b/assets/sass/_post.scss
@@ -65,23 +65,6 @@
 	margin-top: 50px;
 }
 
-.home,
-.archive {
-
-	#primary article {
-
-		&::after {
-			content: "";
-			border-top: 1px solid var(--color-border);
-			width: 200px;
-			display: block;
-			text-align: center;
-			margin: 0 auto;
-			margin-top: 100px;
-		}
-	}
-}
-
 h1.entry-title,
 h2.entry-title,
 h3.entry-title,

--- a/assets/sass/_separator.scss
+++ b/assets/sass/_separator.scss
@@ -1,0 +1,24 @@
+// Terminal-window chrome reused from the logo as a content-block separator.
+// Colors come only from --color-text (no hardcoded fills), so it adapts to the
+// active color scheme exactly like the logo's .lm shapes.
+.separator {
+	margin: 0 auto;
+	margin-top: 60px;
+	margin-bottom: 30px;
+
+	.separator-chrome {
+		display: block;
+		width: 100%;
+		height: auto;
+	}
+
+	.lm {
+		fill: var(--color-text);
+	}
+}
+
+// The first separator on a feed/single sits right under the header — trim its
+// top margin so it doesn't push the first block down excessively.
+#primary > .separator:first-child {
+	margin-top: 30px;
+}

--- a/assets/sass/_separator.scss
+++ b/assets/sass/_separator.scss
@@ -1,15 +1,20 @@
 // Terminal-window chrome reused from the logo as a content-block separator.
-// Colors come only from --color-text (no hardcoded fills), so it adapts to the
-// active color scheme exactly like the logo's .lm shapes.
+// The bar is a fixed-thickness full-width border (flexible width) and the dots
+// are a fixed-size SVG, so both match the logo's chrome exactly at any width.
+// Sizes derive from the logo at 300px (scale 0.617): bar 5u -> ~3px, dots 20u
+// dia -> ~12.34px (66px-wide dots SVG over a 107u viewBox). Color comes only
+// from --color-text, so it adapts to the color scheme like the logo's .lm.
 .separator {
 	margin: 0 auto;
 	margin-top: 80px;
 	margin-bottom: 8px;
+	border-top: 3px solid var(--color-text);
 
 	.separator-chrome {
 		display: block;
-		width: 100%;
+		width: 66px;
 		height: auto;
+		margin-top: 6px;
 	}
 
 	.lm {

--- a/assets/sass/_separator.scss
+++ b/assets/sass/_separator.scss
@@ -5,9 +5,7 @@
 // dia -> ~12.34px (66px-wide dots SVG over a 107u viewBox). Color comes only
 // from --color-text, so it adapts to the color scheme like the logo's .lm.
 .separator {
-	margin: 0 auto;
-	margin-top: 80px;
-	margin-bottom: 8px;
+	margin: 80px auto 8px;
 	border-top: 3px solid var(--color-text);
 
 	.separator-chrome {
@@ -20,6 +18,12 @@
 	.lm {
 		fill: var(--color-text);
 	}
+}
+
+// A full-width featured-image post is designed flush against the header, so
+// drop the separator that would otherwise sit above its hero.
+.separator:has(+ .has-full-width-featured-image) {
+	display: none;
 }
 
 // The first separator on a feed/single sits right under the header — trim its

--- a/assets/sass/_separator.scss
+++ b/assets/sass/_separator.scss
@@ -3,8 +3,8 @@
 // active color scheme exactly like the logo's .lm shapes.
 .separator {
 	margin: 0 auto;
-	margin-top: 60px;
-	margin-bottom: 30px;
+	margin-top: 80px;
+	margin-bottom: 8px;
 
 	.separator-chrome {
 		display: block;
@@ -20,5 +20,5 @@
 // The first separator on a feed/single sits right under the header — trim its
 // top margin so it doesn't push the first block down excessively.
 #primary > .separator:first-child {
-	margin-top: 30px;
+	margin-top: 40px;
 }

--- a/assets/sass/responsive_default.scss
+++ b/assets/sass/responsive_default.scss
@@ -2,6 +2,7 @@
 @import "mixins";
 
 .site-navigation,
+.separator,
 .site-header .meta-navigation,
 .site-header .site-branding,
 .site-header .page-banner #page-title,

--- a/assets/sass/responsive_narrow.scss
+++ b/assets/sass/responsive_narrow.scss
@@ -7,6 +7,7 @@ html {
 }
 
 #sidebar,
+.separator,
 .site-header .meta-navigation,
 .site-header .site-branding,
 .site-header .page-banner #page-description,

--- a/assets/sass/responsive_wide.scss
+++ b/assets/sass/responsive_wide.scss
@@ -3,6 +3,7 @@
 @import "mixins";
 
 #sidebar,
+.separator,
 .site-navigation,
 .site-header .meta-navigation,
 .site-header .site-branding,
@@ -10,6 +11,22 @@
 .site-header .page-banner #page-description,
 .has-full-width-featured-image .entry-header .entry-header-wrapper > * {
 	width: $wide-width;
+}
+
+// Content column matches the header width on wide screens.
+.entry-content > *,
+.entry-summary > *,
+.entry-content > form,
+.entry-content > div,
+.entry-header,
+.entry-footer > *,
+.entry-reaction,
+#comments,
+#nav-above,
+#nav-below,
+.reaction-list,
+.wp-block-quote.is-style-large {
+	max-width: $wide-width;
 }
 
 .entry-content {

--- a/assets/sass/responsive_wide.scss
+++ b/assets/sass/responsive_wide.scss
@@ -13,11 +13,12 @@
 	width: $wide-width;
 }
 
-// Content column matches the header width on wide screens.
-.entry-content > *,
-.entry-summary > *,
-.entry-content > form,
-.entry-content > div,
+// Content column matches the header width on wide screens. Exclude full-width
+// (.alignfull) blocks so Gutenberg full-bleed alignment keeps working.
+.entry-content > *:not(.alignfull),
+.entry-summary > *:not(.alignfull),
+.entry-content > form:not(.alignfull),
+.entry-content > div:not(.alignfull),
 .entry-header,
 .entry-footer > *,
 .entry-reaction,

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -99,6 +99,7 @@ textarea {
 @import "nav";
 @import "logo";
 @import "meta-navigation";
+@import "separator";
 @import "table";
 @import "media";
 @import "sidebar";

--- a/assets/svg/separator.svg
+++ b/assets/svg/separator.svg
@@ -1,6 +1,5 @@
-<svg class="separator-chrome" viewBox="0 0 1200 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-	<rect class="lm" width="1200" height="5" />
-	<circle class="lm" cx="30" cy="25" r="10" />
-	<circle class="lm" cx="63" cy="25" r="10" />
-	<circle class="lm" cx="97" cy="25" r="10" />
+<svg class="separator-chrome" viewBox="0 0 107 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+	<circle class="lm" cx="30" cy="10" r="10" />
+	<circle class="lm" cx="63" cy="10" r="10" />
+	<circle class="lm" cx="97" cy="10" r="10" />
 </svg>

--- a/assets/svg/separator.svg
+++ b/assets/svg/separator.svg
@@ -1,0 +1,6 @@
+<svg class="separator-chrome" viewBox="0 0 1200 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+	<rect class="lm" width="1200" height="5" />
+	<circle class="lm" cx="30" cy="25" r="10" />
+	<circle class="lm" cx="63" cy="25" r="10" />
+	<circle class="lm" cx="97" cy="25" r="10" />
+</svg>

--- a/index.php
+++ b/index.php
@@ -34,6 +34,7 @@ get_header(); ?>
 					 * If you want to overload this in a child theme then include a file
 					 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 					 */
+				Tags::separator();
 				get_template_part( 'templates/content', get_post_format( $post ) );
 				?>
 

--- a/page.php
+++ b/page.php
@@ -23,6 +23,8 @@ get_header(); ?>
 				the_post();
 				?>
 
+				<?php Tags::separator(); ?>
+
 				<?php get_template_part( 'templates/content', 'page' ); ?>
 
 				<?php comments_template( '', true ); ?>

--- a/single.php
+++ b/single.php
@@ -19,6 +19,8 @@ get_header(); ?>
 				global $post;
 				?>
 
+				<?php Tags::separator(); ?>
+
 				<?php get_template_part( 'templates/content', get_post_format( $post ) ); ?>
 
 				<?php

--- a/src/Template/Tags.php
+++ b/src/Template/Tags.php
@@ -295,4 +295,16 @@ class Tags {
 	public static function entry_title_tag(): void {
 		echo is_singular() ? 'h1' : 'h2'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Hardcoded tag names.
 	}
+
+	/**
+	 * Display the terminal-chrome separator that heads a content block.
+	 *
+	 * Outputs the decorative bar-and-dots mark reused from the site logo.
+	 *
+	 * @return void
+	 */
+	public static function separator(): void {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Trusted theme-bundled SVG markup.
+		echo '<div class="separator" role="presentation">' . Svg::get( 'separator' ) . '</div>';
+	}
 }

--- a/src/Template/Tags.php
+++ b/src/Template/Tags.php
@@ -304,7 +304,13 @@ class Tags {
 	 * @return void
 	 */
 	public static function separator(): void {
+		$svg = Svg::get( 'separator' );
+
+		if ( \trim( $svg ) === '' ) {
+			return;
+		}
+
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Trusted theme-bundled SVG markup.
-		echo '<div class="separator" role="presentation">' . Svg::get( 'separator' ) . '</div>';
+		echo '<div class="separator" role="presentation">' . $svg . '</div>';
 	}
 }

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -7,7 +7,19 @@ global $post; // Set by the_post() in calling template.
 
 <header class="entry-header">
 	<div class="entry-header-wrapper">
-		<div class="entry-meta post-format">
+		<?php
+		if ( ! in_array( get_post_format( $post ), [ 'aside', 'quote', 'status' ], true ) && ! empty( get_the_title() ) ) {
+			?>
+		<<?php Tags::entry_title_tag(); ?> class="entry-title p-name">
+			<?php // translators: %s: Post title. ?>
+			<a href="<?php the_permalink(); ?>" class="u-url url" title="<?php printf( esc_attr__( 'Permalink to %s', 'sovereignty' ), the_title_attribute( [ 'echo' => false ] ) ); ?>" rel="bookmark">
+				<?php the_title(); ?>
+			</a>
+		</<?php Tags::entry_title_tag(); ?>>
+		<?php } ?>
+
+		<div class="entry-meta">
+			<?php Tags::posted_by( $post ); ?> <span class="sep"> · </span> <?php Tags::posted_on( $post ); ?> <span class="sep"> · </span> <?php Tags::reading_time( $post ); ?> <span class="sep"> · </span>
 			<?php
 			/**
 			 * Filters the post format link HTML.
@@ -27,21 +39,6 @@ global $post; // Set by the_post() in calling template.
 				),
 			);
 			?>
-		</div>
-
-		<?php
-		if ( ! in_array( get_post_format( $post ), [ 'aside', 'quote', 'status' ], true ) && ! empty( get_the_title() ) ) {
-			?>
-		<<?php Tags::entry_title_tag(); ?> class="entry-title p-name">
-			<?php // translators: %s: Post title. ?>
-			<a href="<?php the_permalink(); ?>" class="u-url url" title="<?php printf( esc_attr__( 'Permalink to %s', 'sovereignty' ), the_title_attribute( [ 'echo' => false ] ) ); ?>" rel="bookmark">
-				<?php the_title(); ?>
-			</a>
-		</<?php Tags::entry_title_tag(); ?>>
-		<?php } ?>
-
-		<div class="entry-meta">
-			<?php Tags::posted_by( $post ); ?> <span class="sep"> · </span> <?php Tags::posted_on( $post ); ?> <span class="sep"> · </span> <?php Tags::reading_time( $post ); ?>
 		</div>
 	</div>
 </header><!-- .entry-header -->

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -11,7 +11,7 @@ global $post; // Set by the_post() in calling template.
 		if ( ! in_array( get_post_format( $post ), [ 'aside', 'quote', 'status' ], true ) && ! empty( get_the_title() ) ) {
 			?>
 		<<?php Tags::entry_title_tag(); ?> class="entry-title p-name">
-			<?php // translators: %s: Post title. ?>
+			<?php /* translators: %s: Post title. */ ?>
 			<a href="<?php the_permalink(); ?>" class="u-url url" title="<?php printf( esc_attr__( 'Permalink to %s', 'sovereignty' ), the_title_attribute( [ 'echo' => false ] ) ); ?>" rel="bookmark">
 				<?php the_title(); ?>
 			</a>


### PR DESCRIPTION
Adds a terminal-window-chrome separator — the bar + three traffic-light dots reused from the logo — that heads each content block, and aligns the content column to the header width.

## What it does
- **`Tags::separator()`** + **`assets/svg/separator.svg`** — the logo's `.lm` bar and dots, no hardcoded fills.
- Inserted at the **top of each content block**: every preview on home/archive, and once on single posts and pages.
- **Removes** the old redundant 200px line between feed articles (no double dividers).
- **Color via `--color-text` only**, so the bar and dots switch with the color scheme exactly like the logo (`$dark-gray` in light → `$white` in dark) — verified in both modes.
- Sized to the **content column**, centered.

## Content width
On wide screens the content column (body text, entry header/footer, comments, post nav) and the separator now widen to `$wide-width` to **match the site header**, so the logo, separator, title, and body all share the same left edge and width. (Previously the content sat in a narrower 700px column under a 900px header.)

## Verification (DDEV, light + dark)
- Home/archive: one separator per preview, old line divider gone.
- Single & page: one separator at the top.
- Header, separator, entry-header, and paragraph all measure `l:143 → r:1043` (900px) on wide.
- Dark mode: bar+dots fill switches to white, visible against the gradient body.
- Build, Stylelint, PHPCS, PHPStan all pass.

Targets `feature/2.0.0`.