### PR TITLE
feat(footer): separator divider + reworded credit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ assets/css/*.css
 assets/css/*.min.css
 assets/css/*.css.map
 .claude/settings.local.json
+
+# Local scratch / parked experiments (not part of the theme)
+_misc_cd/

--- a/assets/sass/_darkmode.scss
+++ b/assets/sass/_darkmode.scss
@@ -4,6 +4,7 @@
 	--color-body-bg: radial-gradient(circle at center, #eee 0%, #ddd 100%);
 	--color-surface: #{$white};
 	--color-surface-alt: #{$background-gray};
+	--color-footer-bg: #{$border-gray};
 
 	// Text.
 	--color-text: #{$dark-gray};
@@ -46,6 +47,7 @@
 		--color-body-bg: radial-gradient(circle at center, #222 0%, #111 100%);
 		--color-surface: #{$dark-gray};
 		--color-surface-alt: #{$gray};
+		--color-footer-bg: #0a0a0a;
 
 		--color-text: #{$white};
 		--color-text-muted: #{$very-light-gray};

--- a/assets/sass/_footer.scss
+++ b/assets/sass/_footer.scss
@@ -1,6 +1,8 @@
 #colophon {
 	width: 100%;
 	margin-top: 80px;
+	border-top: 3px solid rgba(#fff, .2);
+	background-color: #111;
 	content-visibility: auto;
 
 	@include clearfix;
@@ -8,17 +10,23 @@
 
 #site-generator {
 	clear: both;
-	padding-bottom: 4em;
+	padding: 0 20px 4em;
 	text-align: center;
 	font-family: $font-sans;
 	font-size: .9em;
 	line-height: 1.9;
-	color: var(--color-text-muted);
+	color: rgba(#fff, .6);
 
-	// Reuse the content separator (full-width rule + three dots) as the divider.
+	// Reuse the content separator for the three dots (kept at the content-column
+	// position), but the full-width rule is the #colophon border above — so drop
+	// the component's own content-width bar. Tint the dots light for the dark band.
 	.separator {
-		margin-top: 0;
-		margin-bottom: 1.6em;
+		margin: 0 auto 1.8em;
+		border-top: 0;
+
+		.lm {
+			fill: rgba(#fff, .55);
+		}
 	}
 }
 
@@ -29,7 +37,7 @@
 	}
 
 	a {
-		color: var(--color-text-muted);
+		color: rgba(#fff, .82);
 		text-decoration: underline;
 		text-decoration-thickness: 1px;
 		text-underline-offset: 3px;

--- a/assets/sass/_footer.scss
+++ b/assets/sass/_footer.scss
@@ -1,7 +1,7 @@
 #colophon {
 	width: 100%;
-	margin-top: 100px;
-	background-color: var(--color-surface-alt);
+	margin-top: 80px;
+	border-top: 1px solid var(--color-border);
 	content-visibility: auto;
 
 	@include clearfix;
@@ -9,55 +9,37 @@
 
 #site-generator {
 	clear: both;
-	padding: 50px 20px 70px;
+	padding: 2.5em 20px 4em;
+	text-align: center;
+	font-family: $font-sans;
+	font-size: .9em;
+	line-height: 1.9;
+	color: var(--color-text-muted);
 }
 
-// Credit rendered as a small terminal window, echoing the logo and code blocks:
-// green-on-dark and mode-independent (no light/dark variants).
-.site-credit {
-	box-sizing: border-box;
-	max-width: min(90%, 32rem);
-	margin: 0 auto;
-	padding: 2.6em 1.6em 1.6em;
-	position: relative;
-	border-radius: 6px;
-	background: var(--color-code-bg);
-	color: var(--color-code-text);
-	font-family: $font-mono;
-	line-height: 1.6;
-	box-shadow: 0 8px 24px 0 var(--color-shadow);
+// Classic asterism section break above the credit.
+.site-divider {
+	margin: 0 0 1.4em;
+	color: var(--color-text-subtle);
+	font-size: 1.1em;
+	letter-spacing: .4em;
+	text-indent: .4em; // compensate the trailing letter-spacing so it stays centred
+}
 
-	// Window-chrome dots, top-left.
-	.separator-chrome {
-		position: absolute;
-		top: 1.1em;
-		left: 1.6em;
-		width: 42px;
-		height: auto;
-
-		.lm {
-			fill: var(--color-code-text);
-			opacity: .55;
-		}
-	}
+.site-info {
 
 	p {
 		margin: .2em 0;
-
-		&::before {
-			content: "> ";
-			opacity: .55;
-		}
 	}
 
 	a {
-		color: var(--color-code-text);
+		color: var(--color-text-muted);
 		text-decoration: underline;
 		text-decoration-thickness: 1px;
 		text-underline-offset: 3px;
 
 		&:hover {
-			text-decoration-color: var(--color-accent-alt);
+			text-decoration-color: var(--color-accent);
 		}
 	}
 }

--- a/assets/sass/_footer.scss
+++ b/assets/sass/_footer.scss
@@ -2,7 +2,7 @@
 	width: 100%;
 	margin-top: 80px;
 	border-top: 3px solid var(--color-text);
-	background-color: var(--color-surface-alt);
+	background-color: var(--color-footer-bg);
 	content-visibility: auto;
 
 	@include clearfix;

--- a/assets/sass/_footer.scss
+++ b/assets/sass/_footer.scss
@@ -1,14 +1,12 @@
 #colophon {
 	width: 100%;
 	margin-top: 80px;
-	border-top: 3px solid #fff;
-	background-color: #111;
+	border-top: 3px solid var(--color-text);
+	background-color: var(--color-surface-alt);
 	content-visibility: auto;
 
 	@include clearfix;
 
-	// No widgets here by default — drop the sidebar spacing so the dots sit
-	// right under the full-width rule (the usual separator gap).
 	#sidebar {
 		margin: 0;
 	}
@@ -21,18 +19,11 @@
 	font-family: $font-sans;
 	font-size: .9em;
 	line-height: 1.9;
-	color: rgba(#fff, .6);
+	color: var(--color-text-muted);
 
-	// Reuse the content separator for the three dots, kept at the content-column
-	// position. The full-width rule is the #colophon border above, so drop the
-	// component's own (content-width) bar; the dots are white on the dark band.
 	.separator {
 		margin: 0 auto 1.8em;
 		border-top: 0;
-
-		.lm {
-			fill: #fff;
-		}
 	}
 }
 
@@ -43,7 +34,7 @@
 	}
 
 	a {
-		color: rgba(#fff, .82);
+		color: var(--color-text-muted);
 		text-decoration: underline;
 		text-decoration-thickness: 1px;
 		text-underline-offset: 3px;

--- a/assets/sass/_footer.scss
+++ b/assets/sass/_footer.scss
@@ -1,7 +1,6 @@
 #colophon {
 	width: 100%;
 	margin-top: 80px;
-	border-top: 1px solid var(--color-border);
 	content-visibility: auto;
 
 	@include clearfix;
@@ -9,21 +8,18 @@
 
 #site-generator {
 	clear: both;
-	padding: 2.5em 20px 4em;
+	padding-bottom: 4em;
 	text-align: center;
 	font-family: $font-sans;
 	font-size: .9em;
 	line-height: 1.9;
 	color: var(--color-text-muted);
-}
 
-// Classic asterism section break above the credit.
-.site-divider {
-	margin: 0 0 1.4em;
-	color: var(--color-text-subtle);
-	font-size: 1.1em;
-	letter-spacing: .4em;
-	text-indent: .4em; // compensate the trailing letter-spacing so it stays centred
+	// Reuse the content separator (full-width rule + three dots) as the divider.
+	.separator {
+		margin-top: 0;
+		margin-bottom: 1.6em;
+	}
 }
 
 .site-info {

--- a/assets/sass/_footer.scss
+++ b/assets/sass/_footer.scss
@@ -1,0 +1,63 @@
+#colophon {
+	width: 100%;
+	margin-top: 100px;
+	background-color: var(--color-surface-alt);
+	content-visibility: auto;
+
+	@include clearfix;
+}
+
+#site-generator {
+	clear: both;
+	padding: 50px 20px 70px;
+}
+
+// Credit rendered as a small terminal window, echoing the logo and code blocks:
+// green-on-dark and mode-independent (no light/dark variants).
+.site-credit {
+	box-sizing: border-box;
+	max-width: min(90%, 32rem);
+	margin: 0 auto;
+	padding: 2.6em 1.6em 1.6em;
+	position: relative;
+	border-radius: 6px;
+	background: var(--color-code-bg);
+	color: var(--color-code-text);
+	font-family: $font-mono;
+	line-height: 1.6;
+	box-shadow: 0 8px 24px 0 var(--color-shadow);
+
+	// Window-chrome dots, top-left.
+	.separator-chrome {
+		position: absolute;
+		top: 1.1em;
+		left: 1.6em;
+		width: 42px;
+		height: auto;
+
+		.lm {
+			fill: var(--color-code-text);
+			opacity: .55;
+		}
+	}
+
+	p {
+		margin: .2em 0;
+
+		&::before {
+			content: "> ";
+			opacity: .55;
+		}
+	}
+
+	a {
+		color: var(--color-code-text);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 3px;
+
+		&:hover {
+			text-decoration-color: var(--color-accent-alt);
+		}
+	}
+}

--- a/assets/sass/_footer.scss
+++ b/assets/sass/_footer.scss
@@ -1,11 +1,17 @@
 #colophon {
 	width: 100%;
 	margin-top: 80px;
-	border-top: 3px solid rgba(#fff, .2);
+	border-top: 3px solid #fff;
 	background-color: #111;
 	content-visibility: auto;
 
 	@include clearfix;
+
+	// No widgets here by default — drop the sidebar spacing so the dots sit
+	// right under the full-width rule (the usual separator gap).
+	#sidebar {
+		margin: 0;
+	}
 }
 
 #site-generator {
@@ -17,15 +23,15 @@
 	line-height: 1.9;
 	color: rgba(#fff, .6);
 
-	// Reuse the content separator for the three dots (kept at the content-column
-	// position), but the full-width rule is the #colophon border above — so drop
-	// the component's own content-width bar. Tint the dots light for the dark band.
+	// Reuse the content separator for the three dots, kept at the content-column
+	// position. The full-width rule is the #colophon border above, so drop the
+	// component's own (content-width) bar; the dots are white on the dark band.
 	.separator {
 		margin: 0 auto 1.8em;
 		border-top: 0;
 
 		.lm {
-			fill: rgba(#fff, .55);
+			fill: #fff;
 		}
 	}
 }

--- a/assets/sass/_page.scss
+++ b/assets/sass/_page.scss
@@ -168,22 +168,6 @@
 	margin: 0 auto;
 }
 
-#colophon {
-	width: 100%;
-	background-color: var(--color-surface-alt);
-	margin-top: 100px;
-	content-visibility: auto;
-
-	@include clearfix;
-}
-
-#site-generator {
-	clear: both;
-	padding: 50px 0;
-	text-align: center;
-	background-color: var(--color-surface);
-}
-
 .screen-reader-text,
 .assistive-text {
 	clip: rect(1px 1px 1px 1px);

--- a/assets/sass/_sidebar.scss
+++ b/assets/sass/_sidebar.scss
@@ -8,10 +8,6 @@
 
 	@include clearfix;
 
-	#colophon {
-		margin-top: 100px;
-	}
-
 	h2 {
 		font-size: 1.2em;
 		text-transform: uppercase;

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -103,6 +103,7 @@ textarea {
 @import "table";
 @import "media";
 @import "sidebar";
+@import "footer";
 @import "base";
 @import "block";
 @import "form";

--- a/footer.php
+++ b/footer.php
@@ -27,19 +27,11 @@ use Apermo\Sovereignty\Template\Tags;
 				<p>
 					<?php
 					printf(
-						/* translators: %1$s: Sovereignty theme link, %2$s: Autonomie theme link. */
-						__( '%1$s based on %2$s', 'sovereignty' ),
+						/* translators: %1$s: WordPress link, %2$s: Sovereignty theme link, %3$s: Autonomie theme link. */
+						__( 'This site is powered by %1$s and styled with %2$s, based on %3$s', 'sovereignty' ),
+						'<a href="https://wordpress.org/" rel="generator">WordPress</a>',
 						'<a href="https://github.com/apermo/sovereignty">Sovereignty</a>',
 						'<a href="https://notiz.blog/projects/autonomie/">Autonomie</a>',
-					);
-					?>
-				</p>
-				<p>
-					<?php
-					printf(
-						/* translators: %s: WordPress link. */
-						__( 'Powered by %s', 'sovereignty' ),
-						'<a href="https://wordpress.org/" rel="generator">WordPress</a>',
 					);
 					?>
 				</p>

--- a/footer.php
+++ b/footer.php
@@ -7,6 +7,9 @@
  * @package Sovereignty
  * @since Sovereignty 1.0.0
  */
+
+use Apermo\Sovereignty\Template\Svg;
+
 ?>
 	<footer id="colophon">
 		<?php get_sidebar(); ?>
@@ -18,16 +21,30 @@
 			 */
 			do_action( 'sovereignty_credits' );
 			?>
-			<?php
-			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains intentional HTML links for attribution.
-			printf(
-				// translators: %1$s: Link to WordPress, %2$s: Link to Autonomie theme.
-				__( 'This site is powered by %1$s and styled with the %2$s theme', 'sovereignty' ),
-				'<a href="https://wordpress.org/" rel="generator">WordPress</a>',
-				'<a href="https://notiz.blog/projects/autonomie/">Autonomie</a>',
-			);
-			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
-			?>
+			<div class="site-credit">
+				<?php Svg::print( 'separator' ); ?>
+				<?php // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional attribution links. ?>
+				<p>
+					<?php
+					printf(
+						/* translators: %1$s: Sovereignty theme link, %2$s: Autonomie theme link. */
+						__( '%1$s based on %2$s', 'sovereignty' ),
+						'<a href="https://github.com/apermo/sovereignty">Sovereignty</a>',
+						'<a href="https://notiz.blog/projects/autonomie/">Autonomie</a>',
+					);
+					?>
+				</p>
+				<p>
+					<?php
+					printf(
+						/* translators: %s: WordPress link. */
+						__( 'Powered by %s', 'sovereignty' ),
+						'<a href="https://wordpress.org/" rel="generator">WordPress</a>',
+					);
+					?>
+				</p>
+				<?php // phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			</div>
 		</div>
 	</footer><!-- #colophon -->
 </div><!-- #page -->

--- a/footer.php
+++ b/footer.php
@@ -7,6 +7,9 @@
  * @package Sovereignty
  * @since Sovereignty 1.0.0
  */
+
+use Apermo\Sovereignty\Template\Tags;
+
 ?>
 	<footer id="colophon">
 		<?php get_sidebar(); ?>
@@ -18,7 +21,7 @@
 			 */
 			do_action( 'sovereignty_credits' );
 			?>
-			<p class="site-divider" aria-hidden="true">* * *</p>
+			<?php Tags::separator(); ?>
 			<div class="site-info">
 				<?php // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional attribution links. ?>
 				<p>

--- a/footer.php
+++ b/footer.php
@@ -7,9 +7,6 @@
  * @package Sovereignty
  * @since Sovereignty 1.0.0
  */
-
-use Apermo\Sovereignty\Template\Svg;
-
 ?>
 	<footer id="colophon">
 		<?php get_sidebar(); ?>
@@ -21,8 +18,8 @@ use Apermo\Sovereignty\Template\Svg;
 			 */
 			do_action( 'sovereignty_credits' );
 			?>
-			<div class="site-credit">
-				<?php Svg::print( 'separator' ); ?>
+			<p class="site-divider" aria-hidden="true">* * *</p>
+			<div class="site-info">
 				<?php // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional attribution links. ?>
 				<p>
 					<?php

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>.ddev/*</exclude-pattern>
 	<exclude-pattern>bin/*</exclude-pattern>
+	<exclude-pattern>_misc_cd/*</exclude-pattern>
 
 	<!-- Test files: allow non-prefixed globals and WP test constants -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,7 @@ parameters:
             - node_modules (?)
             - .ddev (?)
             - tests (?)
+            - _misc_cd (?)
         analyse:
             - vendor
     scanDirectories:


### PR DESCRIPTION
Footer facelift: use the theme's separator (full-width rule + three dots) as the footer divider, above a muted, centered credit.

## What changed
- **Divider:** reuse the content separator (`Tags::separator()` — the bar + three dots) to head the footer, consistent with the content-block separators and full content-width. Adapts light/dark via `--color-text`.
- **Credit reworded** to **"Sovereignty based on Autonomie"** + **"Powered by WordPress"** (Sovereignty → theme repo, Autonomie → notiz.blog, WordPress keeps `rel="generator"`), centered and muted with accent-underlined links.
- Footer styles consolidated in `_footer.scss`; removed the old flat `#colophon`/`#site-generator` bands (`_page.scss`) and a dead `#sidebar #colophon` rule (`_sidebar.scss`).

## Notes
- Branch history includes two set-aside iterations (a terminal-window card, then an asterism); the net diff is the separator-divider footer above. The terminal-card code is parked in a gitignored `_misc_cd/` (excluded from PHPCS/PHPStan).

## Verification (DDEV, light + dark)
- Footer shows the full-width separator + centered credit; links resolve correctly; adapts in both schemes. Build, Stylelint, PHPCS, PHPStan all pass.

Targets `feature/2.0.0`.