### PR TITLE
fix: header divider, page-banner jump, share button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ plan.md
 tests/e2e/results/
 test-results/
 playwright-report/
+.playwright-mcp/
 .phpunit.cache/
 style.css
 style.css.map

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -30,10 +30,10 @@
 					?.getAttribute('href') || window.location.href,
 		};
 
-		// Web Share is reliable on mobile but flaky/absent on desktop, so fall
-		// back to the panel whenever it cannot handle the post or the share is
-		// dismissed for any reason other than the user cancelling it.
-		if (navigator.canShare && navigator.canShare(shareData)) {
+		// Prefer the native share sheet wherever it exists; fall back to the
+		// panel only when Web Share is absent or the share actually fails
+		// (but not when the user simply cancels the sheet).
+		if (navigator.share) {
 			try {
 				await navigator.share(shareData);
 				return;

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -25,9 +25,8 @@
 		const shareData = {
 			title: document.title,
 			url:
-				document
-					.querySelector('link[rel="canonical"]')
-					?.getAttribute('href') || window.location.href,
+				document.querySelector('link[rel="canonical"]')?.href ||
+				window.location.href,
 		};
 
 		// Prefer the native share sheet wherever it exists; fall back to the

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -1,8 +1,9 @@
 /**
  * share.js
  *
- * Handles the share button: uses Web Share API if available,
- * otherwise toggles a fallback share options panel.
+ * Wires up the share button: uses the Web Share API when the browser can
+ * handle the post, and otherwise — or if sharing fails — reveals the fallback
+ * panel with the post's shortlink, permalink and citation HTML.
  */
 (function () {
 	const entryShare = document.getElementById('entry-share');
@@ -11,22 +12,38 @@
 		return;
 	}
 
-	entryShare.addEventListener('click', function (event) {
+	const toggleFallback = function () {
+		const shareOptions = document.getElementById('share-options');
+		if (shareOptions) {
+			shareOptions.classList.toggle('is-visible');
+		}
+	};
+
+	entryShare.addEventListener('click', async function (event) {
 		event.preventDefault();
 
-		if (navigator.share) {
-			navigator.share({
-				title: document.title,
-				url:
-					document
-						.querySelector('link[rel="canonical"]')
-						?.getAttribute('href') || window.location.href,
-			});
-		} else {
-			const shareOptions = document.getElementById('share-options');
-			if (shareOptions) {
-				shareOptions.classList.toggle('is-visible');
+		const shareData = {
+			title: document.title,
+			url:
+				document
+					.querySelector('link[rel="canonical"]')
+					?.getAttribute('href') || window.location.href,
+		};
+
+		// Web Share is reliable on mobile but flaky/absent on desktop, so fall
+		// back to the panel whenever it cannot handle the post or the share is
+		// dismissed for any reason other than the user cancelling it.
+		if (navigator.canShare && navigator.canShare(shareData)) {
+			try {
+				await navigator.share(shareData);
+				return;
+			} catch (error) {
+				if (error.name === 'AbortError') {
+					return;
+				}
 			}
 		}
+
+		toggleFallback();
 	});
 })();

--- a/assets/sass/_nav.scss
+++ b/assets/sass/_nav.scss
@@ -11,7 +11,6 @@
 	@include clearfix;
 
 	ul {
-		border-top: 1px solid var(--color-border);
 		position: relative;
 		z-index: 597;
 		list-style: none;

--- a/assets/sass/_page.scss
+++ b/assets/sass/_page.scss
@@ -3,7 +3,6 @@
 	display: block;
 	position: relative;
 	width: 100%;
-	border-bottom: 1px solid var(--color-border);
 
 	.site-branding {
 		margin: 0 auto;
@@ -38,7 +37,6 @@
 
 	.page-banner {
 		width: 100%;
-		border-top: 1px solid var(--color-border);
 
 		a {
 			color: var(--color-text);
@@ -128,6 +126,18 @@
 			color: var(--color-text);
 			font-weight: 700;
 			cursor: default;
+		}
+	}
+
+	// Divider below the header, built like the footer's: the full-width line is
+	// this wrapper's border, while the dots come from the content-width
+	// .separator with its own bar removed — so both land at the content edge.
+	.header-divider {
+		border-top: 3px solid var(--color-text);
+
+		.separator {
+			margin: 0 auto;
+			border-top: 0;
 		}
 	}
 }

--- a/assets/sass/_separator.scss
+++ b/assets/sass/_separator.scss
@@ -26,8 +26,8 @@
 	display: none;
 }
 
-// The first separator on a feed/single sits right under the header — trim its
-// top margin so it doesn't push the first block down excessively.
+// The header divider already heads the content, so the first in-content
+// separator is redundant.
 #primary > .separator:first-child {
-	margin-top: 40px;
+	display: none;
 }

--- a/header.php
+++ b/header.php
@@ -79,4 +79,8 @@ wp_body_open();
 		</nav><!-- #site-navigation -->
 
 		<?php get_template_part( 'template-parts/page-banner', Functions::get_archive_type() ); ?>
+
+		<div class="header-divider">
+			<?php Tags::separator(); ?>
+		</div>
 	</header><!-- #site-header -->

--- a/template-parts/entry-share.php
+++ b/template-parts/entry-share.php
@@ -1,8 +1,8 @@
-<button type="share" id="entry-share">
+<button type="button" id="entry-share">
 	<?php esc_html_e( 'share', 'sovereignty' ); ?>
 </button>
 
-<div id="share-options" style="display: none;">
+<div id="share-options">
 	<p><strong><?php esc_html_e( 'Sharing is caring', 'sovereignty' ); ?></strong></p>
 	<p>
 		<label for="entry-shortlink"><?php esc_html_e( 'Shortlink', 'sovereignty' ); ?></label>

--- a/template-parts/page-banner.php
+++ b/template-parts/page-banner.php
@@ -3,9 +3,8 @@ use Apermo\Sovereignty\Semantics;
 use Apermo\Sovereignty\Template\Functions;
 ?>
 
-<?php if ( Functions::show_page_banner() ) { ?>
+<?php if ( Functions::show_page_banner() && ( Functions::has_archive_title() || Functions::has_archive_description() ) ) { ?>
 <div class="page-banner">
-	<?php if ( ! is_singular() ) { ?>
 	<div class="page-branding">
 		<?php if ( Functions::has_archive_title() ) { ?>
 		<h1 id="page-title"<?php Semantics::output( 'page-title' ); ?>><?php Functions::render_archive_title(); ?></h1>
@@ -14,6 +13,5 @@ use Apermo\Sovereignty\Template\Functions;
 		<div id="page-description"<?php Semantics::output( 'page-description' ); ?>><?php Functions::render_archive_description(); ?></div>
 		<?php } ?>
 	</div>
-	<?php } ?>
 </div>
 <?php } ?>


### PR DESCRIPTION
Minor header/share fixes on top of the footer facelift (#103).

## Header divider
- Remove the three faint 1px borders inherited from Autonomie (header
  bottom, nav top, page-banner top).
- Add a full-width terminal-chrome divider below the header, reusing the
  footer's construction: a full-width line on the wrapper plus the
  content-width `.separator` (bar removed) for the dots — so the header
  and footer dividers match exactly and the dots align with the content
  separators at every breakpoint.
- Hide the now-redundant first in-content separator.

## Page-banner jump
- `show_page_banner()` is true on the blog home, so an empty
  `.page-branding` rendered when there is no archive title or tagline.
  Its 50px margin made the home header 50px taller than singular pages —
  a visible jump when navigating between them. Render the banner only
  when it has a title or description.

## Share button
- Took the Web Share branch on every browser defining `navigator.share`
  with no `.catch()`, and the fallback panel could never open (inline
  `display:none` overrode the `.is-visible` toggle); the button also used
  the invalid `type="share"`.
- Use `type="button"`, drop the inline style so the CSS toggle works, and
  prefer the native share sheet when available while falling back to the
  panel on absence or real failure (not on user-cancel).

## Chore
- Ignore the `.playwright-mcp/` artifact dir.

All lint (PHPCS, PHPStan L5, ESLint, Stylelint) green. Verified with
Playwright across light/dark and narrow/default/wide breakpoints.