### PR TITLE
fix(a11y): accessibility pass (axe findings)

### DIFF
--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -15,7 +15,8 @@
 	const toggleFallback = function () {
 		const shareOptions = document.getElementById('share-options');
 		if (shareOptions) {
-			shareOptions.classList.toggle('is-visible');
+			const isVisible = shareOptions.classList.toggle('is-visible');
+			entryShare.setAttribute('aria-expanded', String(isVisible));
 		}
 	};
 

--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -24,10 +24,6 @@ svg {
 	fill: var(--color-text);
 }
 
-a:hover {
-	text-decoration: none;
-}
-
 abbr {
 	font-variant: small-caps;
 

--- a/assets/sass/_nav.scss
+++ b/assets/sass/_nav.scss
@@ -221,7 +221,7 @@
 	margin-top: 100px;
 
 	.page-numbers {
-		font-size: 1.5em;
+		font-size: 1.1em;
 		display: inline-block;
 		margin: 0 5px;
 		color: var(--color-text-meta);

--- a/assets/sass/_nav.scss
+++ b/assets/sass/_nav.scss
@@ -26,7 +26,7 @@
 			line-height: 1.5;
 			padding: 7.5px 0;
 			margin-right: 20px;
-			text-decoration: none;
+			text-decoration: underline;
 		}
 
 		li {

--- a/assets/sass/_post.scss
+++ b/assets/sass/_post.scss
@@ -207,10 +207,6 @@ h4.entry-title {
 
 	a {
 		color: var(--color-text-muted);
-		text-decoration: none;
-	}
-
-	a:hover {
 		text-decoration: underline;
 	}
 

--- a/comments.php
+++ b/comments.php
@@ -89,6 +89,13 @@ use Apermo\Sovereignty\Comment;
 		<p class="nocomments"><?php esc_html_e( 'Comments are closed.', 'sovereignty' ); ?></p>
 	<?php } ?>
 
-	<?php comment_form(); ?>
+	<?php
+	comment_form(
+		[
+			'title_reply_before' => '<h2 id="reply-title" class="comment-reply-title">',
+			'title_reply_after'  => '</h2>',
+		],
+	);
+	?>
 
 </div><!-- #comments -->

--- a/header.php
+++ b/header.php
@@ -72,7 +72,7 @@ wp_body_open();
 			?>
 		</div>
 
-		<nav id="site-navigation" class="site-navigation">
+		<nav id="site-navigation" class="site-navigation" aria-label="<?php esc_attr_e( 'Primary', 'sovereignty' ); ?>">
 			<button class="menu-toggle" aria-controls="site-navigation" aria-expanded="false"><?php esc_html_e( 'Primary Menu', 'sovereignty' ); ?></button>
 
 			<?php wp_nav_menu( [ 'theme_location' => 'primary' ] ); ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -5,6 +5,12 @@
  * @package Sovereignty
  * @since Sovereignty 1.0.0
  */
+
+$sovereignty_widget_areas = [
+	'secondary'  => 'sidebar-1',
+	'tertiary'   => 'sidebar-2',
+	'quaternary' => 'sidebar-3',
+];
 ?>
 	<div id="sidebar">
 		<?php
@@ -12,21 +18,19 @@
 		 * Fires before the sidebar widgets.
 		 */
 		do_action( 'sovereignty_before_sidebar' );
+
+		foreach ( $sovereignty_widget_areas as $sovereignty_id => $sovereignty_sidebar ) {
+			ob_start();
+			dynamic_sidebar( $sovereignty_sidebar );
+			$sovereignty_widgets = trim( (string) ob_get_clean() );
+
+			// Skip empty areas so they don't leave hollow landmark elements behind.
+			if ( $sovereignty_widgets === '' ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Widget HTML from core/registered widgets.
+			printf( '<div id="%1$s" class="widget-area">%2$s</div>', esc_attr( $sovereignty_id ), $sovereignty_widgets );
+		}
 		?>
-
-		<div id="secondary" class="widget-area" role="complementary">
-			<?php dynamic_sidebar( 'sidebar-1' ); ?>
-		</div><!-- #secondary .widget-area -->
-
-		<?php if ( is_active_sidebar( 'sidebar-2' ) ) { ?>
-		<div id="tertiary" class="widget-area" role="complementary">
-			<?php dynamic_sidebar( 'sidebar-2' ); ?>
-		</div><!-- #tertiary .widget-area -->
-		<?php } ?>
-
-		<?php if ( is_active_sidebar( 'sidebar-3' ) ) { ?>
-		<div id="quaternary" class="widget-area" role="complementary">
-			<?php dynamic_sidebar( 'sidebar-3' ); ?>
-		</div><!-- #quaternary .widget-area -->
-		<?php } ?>
 	</div>

--- a/src/Compat.php
+++ b/src/Compat.php
@@ -24,7 +24,7 @@ class Compat {
 	 * @return array
 	 */
 	public static function comment_autocomplete( array $fields ): array {
-		$fields['author'] = \preg_replace( '/<input/', '<input autocomplete="nickname name" enterkeyhint="next" ', $fields['author'] );
+		$fields['author'] = \preg_replace( '/<input/', '<input autocomplete="name" enterkeyhint="next" ', $fields['author'] );
 		$fields['email']  = \preg_replace( '/<input/', '<input autocomplete="email" inputmode="email" enterkeyhint="next" ', $fields['email'] );
 		$fields['url']    = \preg_replace( '/<input/', '<input autocomplete="url" inputmode="url" enterkeyhint="send" ', $fields['url'] );
 

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -73,20 +73,20 @@ class Feed {
 	public static function extend_singular_feed_discovery(): void { // phpcs:ignore SlevomatCodingStandard.Functions.FunctionLength.FunctionLength -- @todo Refactor feed discovery logic.
 		$args = [
 			/* translators: Separator between blog name and feed type in feed links */
-			'separator'     => _x( '&raquo;', 'feed link', 'sovereignty' ),
-			/* translators: 1: blog name, 2: separator(raquo), 3: post title */
+			'separator'     => _x( '&#8212;', 'feed link', 'sovereignty' ),
+			/* translators: 1: blog name, 2: separator, 3: post title */
 			'singletitle'   => __( '%1$s %2$s %3$s Comments Feed', 'sovereignty' ),
-			/* translators: 1: blog name, 2: separator(raquo), 3: category name */
+			/* translators: 1: blog name, 2: separator, 3: category name */
 			'cattitle'      => __( '%1$s %2$s %3$s Category Feed', 'sovereignty' ),
-			/* translators: 1: blog name, 2: separator(raquo), 3: tag name */
+			/* translators: 1: blog name, 2: separator, 3: tag name */
 			'tagtitle'      => __( '%1$s %2$s %3$s Tag Feed', 'sovereignty' ),
-			/* translators: 1: blog name, 2: separator(raquo), 3: term name, 4: taxonomy singular name */
+			/* translators: 1: blog name, 2: separator, 3: term name, 4: taxonomy singular name */
 			'taxtitle'      => __( '%1$s %2$s %3$s %4$s Feed', 'sovereignty' ),
-			/* translators: 1: blog name, 2: separator(raquo), 3: author name  */
+			/* translators: 1: blog name, 2: separator, 3: author name  */
 			'authortitle'   => __( '%1$s %2$s Posts by %3$s Feed', 'sovereignty' ),
-			/* translators: 1: blog name, 2: separator(raquo), 3: search phrase */
+			/* translators: 1: blog name, 2: separator, 3: search phrase */
 			'searchtitle'   => __( '%1$s %2$s Search Results for &#8220;%3$s&#8221; Feed', 'sovereignty' ),
-			/* translators: 1: blog name, 2: separator(raquo), 3: post type */
+			/* translators: 1: blog name, 2: separator, 3: post type */
 			'posttypetitle' => __( '%1$s %2$s %3$s Post-Type Feed', 'sovereignty' ),
 		];
 		$feeds = [];

--- a/src/Template/Functions.php
+++ b/src/Template/Functions.php
@@ -209,7 +209,7 @@ class Functions {
 		}
 
 		if ( $name === '' ) {
-			$name = __( 'Anonymous', 'sovereignty' );
+			$name = __( 'No Author', 'sovereignty' );
 		}
 
 		return $name;

--- a/src/Template/Functions.php
+++ b/src/Template/Functions.php
@@ -202,13 +202,13 @@ class Functions {
 	 * @return string The author name.
 	 */
 	public static function author_name( int $author_id ): string {
-		$name = get_the_author_meta( 'display_name', $author_id );
+		$name = (string) get_the_author_meta( 'display_name', $author_id );
 
-		if ( $name === '' ) {
-			$name = get_the_author_meta( 'user_login', $author_id );
+		if ( \trim( $name ) === '' ) {
+			$name = (string) get_the_author_meta( 'user_login', $author_id );
 		}
 
-		if ( $name === '' ) {
+		if ( \trim( $name ) === '' ) {
 			$name = __( 'No Author', 'sovereignty' );
 		}
 

--- a/src/Template/Functions.php
+++ b/src/Template/Functions.php
@@ -190,4 +190,28 @@ class Functions {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains safe HTML.
 		echo self::get_archive_author_meta();
 	}
+
+	/**
+	 * Get an author's display name with fallbacks.
+	 *
+	 * Guarantees a non-empty name so author links always have discernible
+	 * text, even for posts without a resolvable author.
+	 *
+	 * @param int $author_id The author user ID.
+	 *
+	 * @return string The author name.
+	 */
+	public static function author_name( int $author_id ): string {
+		$name = get_the_author_meta( 'display_name', $author_id );
+
+		if ( $name === '' ) {
+			$name = get_the_author_meta( 'user_login', $author_id );
+		}
+
+		if ( $name === '' ) {
+			$name = __( 'Anonymous', 'sovereignty' );
+		}
+
+		return $name;
+	}
 }

--- a/src/Template/Tags.php
+++ b/src/Template/Tags.php
@@ -47,6 +47,10 @@ class Tags {
 		$author_url  = get_author_posts_url( $author_id );
 		$avatar_size = Config::int( 'sovereignty.avatar.size' );
 
+		if ( $author_name === '' ) {
+			$author_name = get_the_author_meta( 'user_login', $author_id );
+		}
+
 		\printf(
 			'<address class="byline">
 				<span class="author p-author vcard hcard h-card">

--- a/src/Template/Tags.php
+++ b/src/Template/Tags.php
@@ -51,6 +51,10 @@ class Tags {
 			$author_name = get_the_author_meta( 'user_login', $author_id );
 		}
 
+		if ( $author_name === '' ) {
+			$author_name = __( 'Anonymous', 'sovereignty' );
+		}
+
 		\printf(
 			'<address class="byline">
 				<span class="author p-author vcard hcard h-card">

--- a/src/Template/Tags.php
+++ b/src/Template/Tags.php
@@ -43,17 +43,9 @@ class Tags {
 	 */
 	public static function posted_by( WP_Post $post ): void {
 		$author_id   = (int) $post->post_author;
-		$author_name = get_the_author_meta( 'display_name', $author_id );
+		$author_name = Functions::author_name( $author_id );
 		$author_url  = get_author_posts_url( $author_id );
 		$avatar_size = Config::int( 'sovereignty.avatar.size' );
-
-		if ( $author_name === '' ) {
-			$author_name = get_the_author_meta( 'user_login', $author_id );
-		}
-
-		if ( $author_name === '' ) {
-			$author_name = __( 'Anonymous', 'sovereignty' );
-		}
 
 		\printf(
 			'<address class="byline">

--- a/src/Template/Tags.php
+++ b/src/Template/Tags.php
@@ -27,8 +27,18 @@ class Tags {
 		<?php if ( is_home() || is_archive() || is_search() ) { ?>
 		<nav id="archive-nav">
 			<div class="assistive-text"><?php esc_html_e( 'Post navigation', 'sovereignty' ); ?></div>
-			<?php // @phpstan-ignore-next-line paginate_links() returns null on single-page results ?>
-			<?php echo wp_kses_post( paginate_links() ?? '' ); ?>
+			<?php
+			$pagination = paginate_links(
+				[
+					/* translators: Previous page link, with a leftwards arrow. */
+					'prev_text' => __( '&larr; Previous', 'sovereignty' ),
+					/* translators: Next page link, with a rightwards arrow. */
+					'next_text' => __( 'Next &rarr;', 'sovereignty' ),
+				],
+			);
+			// @phpstan-ignore-next-line paginate_links() returns null on single-page results.
+			echo wp_kses_post( $pagination ?? '' );
+			?>
 		</nav><!-- #<?php echo esc_html( $nav_id ); ?> -->
 		<?php } ?>
 		<?php

--- a/template-parts/entry-author.php
+++ b/template-parts/entry-author.php
@@ -1,10 +1,11 @@
+<?php use Apermo\Sovereignty\Template\Functions; ?>
 <address class="author p-author vcard hcard h-card">
 	<?php
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns safe HTML.
 	echo get_avatar( get_the_author_meta( 'ID' ), 100 );
 	?>
 	<a class="url uid u-url u-uid fn p-name" href="<?php echo esc_url( get_author_posts_url( (int) get_the_author_meta( 'ID' ) ) ); ?>">
-		<?php echo esc_html( get_the_author() ); ?>
+		<?php echo esc_html( Functions::author_name( (int) get_the_author_meta( 'ID' ) ) ); ?>
 	</a>
 	<div class="note e-note"><?php echo wp_kses_post( get_the_author_meta( 'description' ) ); ?></div>
 	<a class="subscribe" href="<?php echo esc_url( get_author_feed_link( (int) get_the_author_meta( 'ID' ) ) ); ?>"><i class="openwebicons-feed"></i> <?php esc_html_e( 'Subscribe to author feed', 'sovereignty' ); ?></a>

--- a/template-parts/entry-author.php
+++ b/template-parts/entry-author.php
@@ -1,12 +1,19 @@
-<?php use Apermo\Sovereignty\Template\Functions; ?>
+<?php
+use Apermo\Sovereignty\Template\Functions;
+
+$sovereignty_author_id = (int) get_the_author_meta( 'ID' );
+$sovereignty_avatar    = get_avatar( $sovereignty_author_id, 100 );
+?>
 <address class="author p-author vcard hcard h-card">
 	<?php
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns safe HTML.
-	echo get_avatar( get_the_author_meta( 'ID' ), 100 );
+	if ( is_string( $sovereignty_avatar ) && trim( $sovereignty_avatar ) !== '' ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns safe HTML.
+		echo $sovereignty_avatar;
+	}
 	?>
-	<a class="url uid u-url u-uid fn p-name" href="<?php echo esc_url( get_author_posts_url( (int) get_the_author_meta( 'ID' ) ) ); ?>">
-		<?php echo esc_html( Functions::author_name( (int) get_the_author_meta( 'ID' ) ) ); ?>
+	<a class="url uid u-url u-uid fn p-name" href="<?php echo esc_url( get_author_posts_url( $sovereignty_author_id ) ); ?>">
+		<?php echo esc_html( Functions::author_name( $sovereignty_author_id ) ); ?>
 	</a>
 	<div class="note e-note"><?php echo wp_kses_post( get_the_author_meta( 'description' ) ); ?></div>
-	<a class="subscribe" href="<?php echo esc_url( get_author_feed_link( (int) get_the_author_meta( 'ID' ) ) ); ?>"><i class="openwebicons-feed"></i> <?php esc_html_e( 'Subscribe to author feed', 'sovereignty' ); ?></a>
+	<a class="subscribe" href="<?php echo esc_url( get_author_feed_link( $sovereignty_author_id ) ); ?>"><i class="openwebicons-feed"></i> <?php esc_html_e( 'Subscribe to author feed', 'sovereignty' ); ?></a>
 </address>

--- a/template-parts/entry-share.php
+++ b/template-parts/entry-share.php
@@ -1,4 +1,4 @@
-<button type="button" id="entry-share">
+<button type="button" id="entry-share" aria-expanded="false" aria-controls="share-options">
 	<?php esc_html_e( 'share', 'sovereignty' ); ?>
 </button>
 

--- a/templates/content-aside.php
+++ b/templates/content-aside.php
@@ -15,7 +15,7 @@ use Apermo\Sovereignty\Template\Tags;
 global $post; // Set by the_post() in calling template.
 ?>
 
-<aside <?php Tags::post_id( $post ); ?> <?php post_class(); ?><?php Semantics::output( 'post' ); ?>>
+<article <?php Tags::post_id( $post ); ?> <?php post_class(); ?><?php Semantics::output( 'post' ); ?>>
 	<?php get_template_part( 'template-parts/entry-header' ); ?>
 
 	<?php Featured_Image::the_post_thumbnail( $post, '<div class="entry-media">', '</div>' ); ?>
@@ -32,4 +32,4 @@ global $post; // Set by the_post() in calling template.
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>
-</aside><!-- #post-<?php the_ID(); ?> -->
+</article><!-- #post-<?php the_ID(); ?> -->

--- a/tests/Unit/CompatTest.php
+++ b/tests/Unit/CompatTest.php
@@ -49,7 +49,7 @@ class CompatTest extends TestCase {
 
 		$result = Compat::comment_autocomplete( $fields );
 
-		$this->assertStringContainsString( 'autocomplete="nickname name"', $result['author'] );
+		$this->assertStringContainsString( 'autocomplete="name"', $result['author'] );
 		$this->assertStringContainsString( 'enterkeyhint="next"', $result['author'] );
 		$this->assertStringContainsString( 'autocomplete="email"', $result['email'] );
 		$this->assertStringContainsString( 'inputmode="email"', $result['email'] );


### PR DESCRIPTION
Accessibility fixes from an axe-core (Playwright) audit across home, single post, page,
archive, /now/, search and 404, in light and dark, triaged with the maintainer.

## Fixes
- **Author byline / widget**: shared `Functions::author_name()` fallback
  (display_name → user_login → "No Author") so author links always have discernible text
  (`link-name`).
- **Comment form**: valid `autocomplete="name"` (was the invalid `"nickname name"`); reply
  title rendered as `<h2>` so it doesn't skip a level after the post `<h1>` (`heading-order`).
- **Footer widgets**: only emit a widget area when it has content, as a plain `widget-area`
  div (no empty `role="complementary"`), resolving `landmark-complementary-is-top-level` and
  `landmark-unique`.
- **Primary nav**: `aria-label="Primary"` so the two nav landmarks are distinguishable.
- **Aside/status/link posts**: feed entry wrapper changed from `<aside>` to `<article>` so
  these posts aren't spurious complementary landmarks.
- **Share button**: `aria-expanded`/`aria-controls`, state synced with the fallback panel.
- **Link distinguishability**: menu items and meta-row links (post-format type, "Leave a
  comment", date, author, tags) are underlined at rest (WCAG 1.4.1); content links keep
  their underline on hover.

## Out of scope
- Colour/contrast (terminal form-field palette, `prefers-contrast`, forced-colors) — owned by
  #25 / #63. This PR is deliberately colour-neutral; a measurement was added to #25.

Verified with axe: only the dismissed `color-contrast` (brand terminal palette) remains; all
other violation classes cleared. All lint (PHPCS, PHPStan L5, ESLint, Stylelint) green.