### PR TITLE
feat(a11y): high contrast & reduced motion (#25)

### DIFF
--- a/assets/sass/_a11y.scss
+++ b/assets/sass/_a11y.scss
@@ -58,8 +58,10 @@
 	*,
 	*::before,
 	*::after {
+		animation-delay: -1ms !important;
 		animation-duration: 0.01ms !important;
 		animation-iteration-count: 1 !important;
+		transition-delay: 0s !important;
 		transition-duration: 0.01ms !important;
 		scroll-behavior: auto !important;
 	}

--- a/assets/sass/_a11y.scss
+++ b/assets/sass/_a11y.scss
@@ -1,0 +1,66 @@
+// Accessibility preference media queries.
+
+// Honour an explicit request for more contrast: flatten the palette to
+// near-pure values and brighten the terminal green so it clears AAA, while
+// keeping the green-on-dark terminal identity. Everything is driven through the
+// semantic custom properties, so the logo, code blocks and form fields follow.
+@media (prefers-contrast: more) {
+
+	:root {
+		--color-background: #{$white};
+		--color-body-bg: #{$white};
+		--color-surface: #{$white};
+		--color-surface-alt: #{$white};
+		--color-footer-bg: #{$white};
+
+		--color-text: #000;
+		--color-text-muted: #000;
+		--color-text-meta: #000;
+		--color-text-subtle: #000;
+
+		--color-border: #000;
+		--color-accent: #000;
+
+		--color-shadow: transparent;
+
+		// Pure-black terminal background so the bright green hits ~16:1 in the
+		// logo, code blocks and form fields.
+		--color-code-text: #{$terminal-green-bright};
+		--color-code-bg: #000;
+		--color-form-text: #{$terminal-green-bright};
+		--color-form-bg: #000;
+		--color-form-border: #{$terminal-green-bright};
+	}
+
+	@media (prefers-color-scheme: dark) {
+
+		:root {
+			--color-background: #000;
+			--color-body-bg: #000;
+			--color-surface: #000;
+			--color-surface-alt: #000;
+			--color-footer-bg: #000;
+
+			--color-text: #{$white};
+			--color-text-muted: #{$white};
+			--color-text-meta: #{$white};
+			--color-text-subtle: #{$white};
+
+			--color-border: #{$white};
+			--color-accent: #{$white};
+		}
+	}
+}
+
+// Respect a request for reduced motion: neutralise transitions and animations.
+@media (prefers-reduced-motion: reduce) {
+
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+}

--- a/assets/sass/_logo.scss
+++ b/assets/sass/_logo.scss
@@ -36,10 +36,3 @@
 		opacity: 0;
 	}
 }
-
-@media (prefers-reduced-motion: reduce) {
-
-	#logo:hover #cursor {
-		animation: none;
-	}
-}

--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -42,6 +42,8 @@ $very-dark-gray: #444;
 // Terminal aesthetic (green-on-dark), shared with form styling.
 $terminal-green: #1eb100;
 $terminal-green-bg: #203f00;
+// Brighter variant for prefers-contrast: more (9:1 on $terminal-green-bg).
+$terminal-green-bright: #66ff47;
 
 // Selection highlight.
 $selection-bg: #b3d4fc;

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -154,3 +154,4 @@ textarea {
 
 @import "integrations";
 @import "darkmode";
+@import "a11y";


### PR DESCRIPTION
Implements #25 — `prefers-contrast` and `prefers-reduced-motion` support, ported and adapted from
the old theme's `sass/specialmodes/`.

## prefers-contrast: more
New `assets/sass/_a11y.scss` overrides the semantic custom properties (so the logo, code blocks and
form fields follow automatically — no per-element rules):
- Palette flattens to pure black/white in both schemes (text/border/accent and all backgrounds; the
  body radial gradient is flattened).
- Shadows removed (`--color-shadow: transparent`).
- Terminal blocks (logo `.lbg`, code blocks, form fields) switch to a **pure-black background** with
  the brightened green `#66ff47` — ~16:1 (was 4.14:1, which had been dismissed for normal viewing
  and tracked here).

This resolves the previously-dismissed `color-contrast` finding under high contrast (axe: 0
`color-contrast` violations with `prefers-contrast: more`).

## prefers-reduced-motion: reduce
Global rule neutralising transitions/animations (the only animation today is the logo cursor blink).
The logo's local reduced-motion rule is removed as redundant.

## Notes
- Colour-neutral for normal viewing — the standard palette is untouched; these are override-only
  media queries.
- Verified via Playwright `emulateMedia` (contrast/colorScheme/reducedMotion) in light and dark:
  `--color-text` flips to `#000`/`#fff`, terminal text computes `#66ff47`, the logo block goes black,
  and the cursor animation-duration drops to ~0s.
- #63 (forced-colors) and #64 (reduced-transparency) remain separate, out of scope here.
- Merges into `feature/2.0.0`, so #25 won't auto-close; it resolves when 2.0.0 reaches main.