### PR TITLE
feat(style): cross-document view transitions

### DIFF
--- a/assets/sass/_view-transitions.scss
+++ b/assets/sass/_view-transitions.scss
@@ -12,4 +12,15 @@
 	.site-header {
 		view-transition-name: site-header;
 	}
+
+	// The header height varies between pages (the page banner is only
+	// present on some). Override the default object-fit: fill so the
+	// top-aligned branding and navigation stay stable instead of
+	// stretching while the height animates.
+	::view-transition-old(site-header),
+	::view-transition-new(site-header) {
+		height: 100%;
+		object-fit: none;
+		object-position: top left;
+	}
 }

--- a/assets/sass/_view-transitions.scss
+++ b/assets/sass/_view-transitions.scss
@@ -1,0 +1,15 @@
+// Cross-document view transitions. Progressive enhancement; unsupported
+// browsers fall back to instant navigation. Gated on reduced-motion so it
+// composes with the global guard in _a11y.scss.
+@media screen and (prefers-reduced-motion: no-preference) {
+
+	@view-transition {
+		navigation: auto;
+	}
+
+	// Pin the header so it persists across navigations and slides instead
+	// of cross-fading with the content.
+	.site-header {
+		view-transition-name: site-header;
+	}
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -155,3 +155,4 @@ textarea {
 @import "integrations";
 @import "darkmode";
 @import "a11y";
+@import "view-transitions";


### PR DESCRIPTION
Opts the theme frontend into the **CSS View Transitions API** for cross-document
navigation — the same mechanism WordPress 7.0 introduced for wp-admin. No JavaScript
and no markup changes: classic server-rendered navigation is simply allowed to animate.

## Behaviour
- Content **cross-fades** between page loads (browser default root transition).
- The site header (`#site-header`) is given a `view-transition-name`, so it **persists
  and slides** across navigations instead of fading with the content.
- Gated behind `@media (prefers-reduced-motion: no-preference)` — users who request
  reduced motion get instant navigation, composing with the global guard in `_a11y.scss`.
- Progressive enhancement: browsers without cross-document support (currently
  Firefox/Safari) navigate exactly as before.

## Changes
- `assets/sass/_view-transitions.scss` — new partial with the `@view-transition` at-rule
  and the header `view-transition-name`.
- `assets/sass/style.scss` — import the partial.

Pure CSS, no PHP/JS touched. Generated `style.css`/`style.min.css` are gitignored and
built at packaging time.

## Notes
- Distinct from the just-closed #26 (a legacy transition-*suppression* guard with the
  opposite intent) — this is the modern capability and warrants its own tracking issue.
- Stylelint accepts `@view-transition` / `view-transition-name` with no config changes.

## Verification
- `npm run build` succeeds; compiled `style.css` contains the `@view-transition` block.
- `npm run lint:css` passes.
- Manual (Chrome/Edge): navigating between posts/pages cross-fades content while the
  header stays put; with OS reduced-motion enabled, navigation is instant.