### PR TITLE
fix(activitypub): cast author ID to int

### DIFF
--- a/src/Template/Functions.php
+++ b/src/Template/Functions.php
@@ -82,12 +82,12 @@ class Functions {
 			/**
 			 * Filters the follower count for an author archive.
 			 *
-			 * @param int    $count     The follower count.
-			 * @param string $author_id The author user ID.
+			 * @param int $count     The follower count.
+			 * @param int $author_id The author user ID.
 			 *
 			 * @return int The filtered follower count.
 			 */
-			apply_filters( 'sovereignty_archive_author_followers', 0, get_the_author_meta( 'ID' ) ),
+			apply_filters( 'sovereignty_archive_author_followers', 0, (int) get_the_author_meta( 'ID' ) ),
 		);
 		$meta[] = \sprintf(
 			// translators: a post counter.
@@ -104,11 +104,11 @@ class Functions {
 		 * Filters the author archive meta items.
 		 *
 		 * @param string[] $meta      The meta items.
-		 * @param string   $author_id The author user ID.
+		 * @param int      $author_id The author user ID.
 		 *
 		 * @return string[] The filtered meta items.
 		 */
-		$meta = apply_filters( 'sovereignty_archive_author_meta', $meta, get_the_author_meta( 'ID' ) );
+		$meta = apply_filters( 'sovereignty_archive_author_meta', $meta, (int) get_the_author_meta( 'ID' ) );
 
 		return \implode( ' | ', $meta );
 	}


### PR DESCRIPTION
## Problem

Sentry issue [CHRDMDE-7](https://christoph-daum.sentry.io/issues/128792466/) reported a recurring `TypeError`:

> `Apermo\Sovereignty\Integration\ActivityPub::followers(): Argument #2 ($author_id) must be of type int, string given`

## Root cause

`get_the_author_meta( 'ID' )` returns a **string**. In `Template\Functions::get_archive_author_meta()` it was passed directly into two `apply_filters()` calls as `$author_id`. The `ActivityPub` integration declares `strict_types=1` with `int $author_id` parameters, so when the plugin hooks in, PHP throws a `TypeError`.

The two adjacent calls (`count_user_posts()`, `get_author_feed_link()`) already cast `(int) get_the_author_meta( 'ID' )` — the filter call sites just missed it.

## Fix

- Cast `(int) get_the_author_meta( 'ID' )` at both `apply_filters()` call sites in `src/Template/Functions.php`.
- Correct the docblock `@param` types from `string` to `int` to match the actual contract.

## Verification

- `composer cs` — clean
- `composer analyse` (PHPStan level 5) — no errors
- `composer test:unit` — 87 tests pass