### PR TITLE
chore(release): bump version to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-07-19
+
+### Fixed
+
+- `TypeError` on author archives when the ActivityPub plugin is active:
+  `get_the_author_meta( 'ID' )` returned a string but the integration's
+  filter callbacks require an `int`. Author IDs are now cast at the filter
+  call sites.
+
+### Removed
+
+- Gemini Code Assist configuration (`.gemini/config.yaml`,
+  `.gemini/styleguide.md`).
+
 ## [2.0.1] - 2026-06-21
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "apermo/sovereignty",
 	"description": "Pure Zen - Fork of Pfefferle's Autonomie Theme",
 	"type": "wordpress-theme",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"license": "MIT",
 	"homepage": "https://github.com/apermo/sovereignty",
 	"support": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereignty",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "testedUpTo": "7.0",
   "description": "Semantic, responsive WordPress theme with deep IndieWeb support. Fork of Autonomie by Matthias Pfefferle.",
   "repository": {


### PR DESCRIPTION
## Release 2.0.2

Patch release bumping `package.json`, `composer.json`, and `CHANGELOG.md`.
The generated `version.php` and `style.css` are produced by `npm run build`
at packaging time (both gitignored).

### Fixed

- `TypeError` on author archives when the ActivityPub plugin is active — author IDs are now cast to `int` at the filter call sites (#114, Sentry CHRDMDE-7).

### Removed

- Gemini Code Assist configuration (#94).

---

Merging to `main` triggers the release workflow, which auto-tags `v2.0.2`.